### PR TITLE
refactor: inverse computation in Z/16Z

### DIFF
--- a/contracts/PRBMath.sol
+++ b/contracts/PRBMath.sol
@@ -457,7 +457,7 @@ library PRBMath {
             // Invert denominator mod 2^256. Now that denominator is an odd number, it has an inverse modulo 2^256 such
             // that denominator * inv = 1 mod 2^256. Compute the inverse by starting with a seed that is correct for
             // four bits. That is, denominator * inv = 1 mod 2^4.
-            uint256 inverse = (3 * denominator) ^ 2;
+            uint256 inverse = denominator**3;
 
             // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also works
             // in modular arithmetic, doubling the correct bits in each step.


### PR DESCRIPTION
In Z/16Z, `f:x → x**4` is 1 for all inversable (odd) values.

This can be checked in python
```
In[1]: [ x**4 % 16 for denom in range(16) ]
Out[1]: [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
```

Consequently, `g: x → x**3` is the returns the inverse over the same space.

IMO, this is cleaner inverse function than `h: x → (3*x)^2`, which for some reason includes a xor.

Also, my version should be cheaper to compute (on less push, and one less arithmetic op)