### PR TITLE
fix: inconsistency in the sqrt function

### DIFF
--- a/contracts/PRBMath.sol
+++ b/contracts/PRBMath.sol
@@ -628,7 +628,7 @@ library PRBMath {
             xAux >>= 4;
             result <<= 2;
         }
-        if (xAux >= 0x8) {
+        if (xAux >= 0x4) {
             result <<= 1;
         }
 


### PR DESCRIPTION
Fixes #97.

The `sqrt` function using newton methods with a first guess that is the most significant bit of the `sqrt` or x. This is done using an algorithm that is similar to `mostSignificantBit`, but that increase the result by the half of what `mostSignificantBit` does.

While `mostSignificantBit` is correct, `sqrt` uses 0x8 instead of 0x4 for `2**2`

---

Note: a cleaner, but slightly more expensive, version of the code could do
```
function sqrt(uint256 x) internal pure returns (uint256 result) {
        if (x == 0) {
            return 0;
        }

        // Set the initial guess to the least power of two that is greater than or equal to sqrt(x).
        result = 1 << (mostSignificantBit(x) >> 1); 
        
        // The operations can never overflow because the result is max 2^127 when it enters this block.
        unchecked {
            result = (result + x / result) >> 1;
            result = (result + x / result) >> 1;
            result = (result + x / result) >> 1;
            result = (result + x / result) >> 1;
            result = (result + x / result) >> 1;
            result = (result + x / result) >> 1;
            result = (result + x / result) >> 1; // Seven iterations should be enough
            uint256 roundedDownResult = x / result;
            return result >= roundedDownResult ? roundedDownResult : result;
        }
    }
```