### PR TITLE
Use UDVT instead of structs for typed library

### DIFF
--- a/contracts/PRBMath.sol
+++ b/contracts/PRBMath.sol
@@ -97,13 +97,8 @@ error PRBMathUD60x18__SubUnderflow(uint256 x, uint256 y);
 library PRBMath {
     /// STRUCTS ///
 
-    struct SD59x18 {
-        int256 value;
-    }
-
-    struct UD60x18 {
-        uint256 value;
-    }
+    type SD59x18 is int256;
+    type UD60x18 is uint256;
 
     /// STORAGE ///
 

--- a/contracts/PRBMathSD59x18Typed.sol
+++ b/contracts/PRBMathSD59x18Typed.sol
@@ -47,13 +47,13 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The number to calculate the absolute value for.
     /// @param result The absolute value of x.
-    function abs(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function abs(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
         if (xValue == MIN_SD59x18) {
             revert PRBMathSD59x18__AbsInputTooSmall();
         }
         unchecked {
-            result = PRBMath.SD59x18({ value: x.value < 0 ? -xValue : xValue });
+            result = PRBMath.SD59x18.wrap(xValue < 0 ? -xValue : xValue);
         }
     }
 
@@ -62,26 +62,18 @@ library PRBMathSD59x18Typed {
     /// @param x The first summand as a signed 59.18-decimal fixed-point number.
     /// @param y The second summand as a signed 59.18-decimal fixed-point number.
     /// @param result The sum as a signed 59.18 decimal fixed-point number.
-    function add(PRBMath.SD59x18 memory x, PRBMath.SD59x18 memory y)
-        internal
-        pure
-        returns (PRBMath.SD59x18 memory result)
-    {
-        result = PRBMath.SD59x18({ value: x.value + y.value });
+    function add(PRBMath.SD59x18 x, PRBMath.SD59x18 y) internal pure returns (PRBMath.SD59x18 result) {
+        result = PRBMath.SD59x18.wrap(PRBMath.SD59x18.unwrap(x) + PRBMath.SD59x18.unwrap(y));
     }
 
     /// @notice Calculates the arithmetic average of x and y, rounding down.
     /// @param x The first operand as a signed 59.18-decimal fixed-point number.
     /// @param y The second operand as a signed 59.18-decimal fixed-point number.
     /// @return result The arithmetic average as a signed 59.18-decimal fixed-point number.
-    function avg(PRBMath.SD59x18 memory x, PRBMath.SD59x18 memory y)
-        internal
-        pure
-        returns (PRBMath.SD59x18 memory result)
-    {
+    function avg(PRBMath.SD59x18 x, PRBMath.SD59x18 y) internal pure returns (PRBMath.SD59x18 result) {
         // The operations can never overflow.
-        int256 xValue = x.value;
-        int256 yValue = y.value;
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
+        int256 yValue = PRBMath.SD59x18.unwrap(y);
         int256 rValue;
         unchecked {
             int256 sum = (xValue >> 1) + (yValue >> 1);
@@ -97,7 +89,7 @@ library PRBMathSD59x18Typed {
                 rValue = sum + (xValue & yValue & 1);
             }
         }
-        result = PRBMath.SD59x18({ value: rValue });
+        result = PRBMath.SD59x18.wrap(rValue);
     }
 
     /// @notice Yields the least greatest signed 59.18 decimal fixed-point number greater than or equal to x.
@@ -110,8 +102,8 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The signed 59.18-decimal fixed-point number to ceil.
     /// @param result The least integer greater than or equal to x, as a signed 58.18-decimal fixed-point number.
-    function ceil(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function ceil(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
         if (xValue > MAX_WHOLE_SD59x18) {
             revert PRBMathSD59x18__CeilOverflow(xValue);
         }
@@ -125,7 +117,7 @@ library PRBMathSD59x18Typed {
                 if (xValue > 0) {
                     rValue += SCALE;
                 }
-                result = PRBMath.SD59x18({ value: rValue });
+                result = PRBMath.SD59x18.wrap(rValue);
             }
         }
     }
@@ -146,13 +138,9 @@ library PRBMathSD59x18Typed {
     /// @param x The numerator as a signed 59.18-decimal fixed-point number.
     /// @param y The denominator as a signed 59.18-decimal fixed-point number.
     /// @param result The quotient as a signed 59.18-decimal fixed-point number.
-    function div(PRBMath.SD59x18 memory x, PRBMath.SD59x18 memory y)
-        internal
-        pure
-        returns (PRBMath.SD59x18 memory result)
-    {
-        int256 xValue = x.value;
-        int256 yValue = y.value;
+    function div(PRBMath.SD59x18 x, PRBMath.SD59x18 y) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
+        int256 yValue = PRBMath.SD59x18.unwrap(y);
         if (xValue == MIN_SD59x18 || yValue == MIN_SD59x18) {
             revert PRBMathSD59x18__DivInputTooSmall();
         }
@@ -181,13 +169,13 @@ library PRBMathSD59x18Typed {
 
         // XOR over sx and sy. This is basically checking whether the inputs have the same sign. If yes, the result
         // should be positive. Otherwise, it should be negative.
-        result = PRBMath.SD59x18({ value: sx ^ sy == 1 ? -int256(rAbs) : int256(rAbs) });
+        result = PRBMath.SD59x18.wrap(sx ^ sy == 1 ? -int256(rAbs) : int256(rAbs));
     }
 
     /// @notice Returns Euler's number as a signed 59.18-decimal fixed-point number.
     /// @dev See https://en.wikipedia.org/wiki/E_(mathematical_constant).
-    function e() internal pure returns (PRBMath.SD59x18 memory result) {
-        result = PRBMath.SD59x18({ value: 2_718281828459045235 });
+    function e() internal pure returns (PRBMath.SD59x18 result) {
+        result = PRBMath.SD59x18.wrap(2_718281828459045235);
     }
 
     /// @notice Calculates the natural exponent of x.
@@ -204,11 +192,11 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The exponent as a signed 59.18-decimal fixed-point number.
     /// @return result The result as a signed 59.18-decimal fixed-point number.
-    function exp(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function exp(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
         // Without this check, the value passed to "exp2" would be less than -59.794705707972522261.
         if (xValue < -41_446531673892822322) {
-            return PRBMath.SD59x18({ value: 0 });
+            return PRBMath.SD59x18.wrap(0);
         }
 
         // Without this check, the value passed to "exp2" would be greater than 192.
@@ -219,7 +207,7 @@ library PRBMathSD59x18Typed {
         // Do the fixed-point multiplication inline to save gas.
         unchecked {
             int256 doubleScaleProduct = xValue * LOG2_E;
-            PRBMath.SD59x18 memory exponent = PRBMath.SD59x18({ value: (doubleScaleProduct + HALF_SCALE) / SCALE });
+            PRBMath.SD59x18 exponent = PRBMath.SD59x18.wrap((doubleScaleProduct + HALF_SCALE) / SCALE);
             result = exp2(exponent);
         }
     }
@@ -237,20 +225,20 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The exponent as a signed 59.18-decimal fixed-point number.
     /// @return result The result as a signed 59.18-decimal fixed-point number.
-    function exp2(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function exp2(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
 
         // This works because 2^(-x) = 1/2^x.
         if (xValue < 0) {
             // 2^59.794705707972522262 is the maximum number whose inverse does not truncate down to zero.
             if (xValue < -59_794705707972522261) {
-                return PRBMath.SD59x18({ value: 0 });
+                return PRBMath.SD59x18.wrap(0);
             }
 
             // Do the fixed-point inversion inline to save gas. The numerator is SCALE * SCALE.
             unchecked {
-                PRBMath.SD59x18 memory exponent = PRBMath.SD59x18({ value: -xValue });
-                result = PRBMath.SD59x18({ value: 1e36 / exp2(exponent).value });
+                PRBMath.SD59x18 exponent = PRBMath.SD59x18.wrap(-xValue);
+                result = PRBMath.SD59x18.wrap(1e36 / PRBMath.SD59x18.unwrap(exp2(exponent)));
             }
         } else {
             // 2^192 doesn't fit within the 192.64-bit format used internally in this function.
@@ -263,7 +251,7 @@ library PRBMathSD59x18Typed {
                 uint256 x192x64 = (uint256(xValue) << 64) / uint256(SCALE);
 
                 // Safe to convert the result to int256 directly because the maximum input allowed is 192.
-                result = PRBMath.SD59x18({ value: int256(PRBMath.exp2(x192x64)) });
+                result = PRBMath.SD59x18.wrap(int256(PRBMath.exp2(x192x64)));
             }
         }
     }
@@ -278,8 +266,8 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The signed 59.18-decimal fixed-point number to floor.
     /// @param result The greatest integer less than or equal to x, as a signed 58.18-decimal fixed-point number.
-    function floor(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function floor(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
         if (xValue < MIN_WHOLE_SD59x18) {
             revert PRBMathSD59x18__FloorUnderflow(xValue);
         }
@@ -293,7 +281,7 @@ library PRBMathSD59x18Typed {
                 if (xValue < 0) {
                     rValue -= SCALE;
                 }
-                result = PRBMath.SD59x18({ value: rValue });
+                result = PRBMath.SD59x18.wrap(rValue);
             }
         }
     }
@@ -303,9 +291,9 @@ library PRBMathSD59x18Typed {
     /// @dev Based on the odd function definition. https://en.wikipedia.org/wiki/Fractional_part
     /// @param x The signed 59.18-decimal fixed-point number to get the fractional part of.
     /// @param result The fractional part of x as a signed 59.18-decimal fixed-point number.
-    function frac(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
+    function frac(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
         unchecked {
-            result = PRBMath.SD59x18({ value: x.value % SCALE });
+            result = PRBMath.SD59x18.wrap(PRBMath.SD59x18.unwrap(x) % SCALE);
         }
     }
 
@@ -317,7 +305,7 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The basic integer to convert.
     /// @param result The same number in signed 59.18-decimal fixed-point representation.
-    function fromInt(int256 x) internal pure returns (PRBMath.SD59x18 memory result) {
+    function fromInt(int256 x) internal pure returns (PRBMath.SD59x18 result) {
         unchecked {
             if (x < MIN_SD59x18 / SCALE) {
                 revert PRBMathSD59x18__FromIntUnderflow(x);
@@ -325,7 +313,7 @@ library PRBMathSD59x18Typed {
             if (x > MAX_SD59x18 / SCALE) {
                 revert PRBMathSD59x18__FromIntOverflow(x);
             }
-            result = PRBMath.SD59x18({ value: x * SCALE });
+            result = PRBMath.SD59x18.wrap(x * SCALE);
         }
     }
 
@@ -338,30 +326,28 @@ library PRBMathSD59x18Typed {
     /// @param x The first operand as a signed 59.18-decimal fixed-point number.
     /// @param y The second operand as a signed 59.18-decimal fixed-point number.
     /// @return result The result as a signed 59.18-decimal fixed-point number.
-    function gm(PRBMath.SD59x18 memory x, PRBMath.SD59x18 memory y)
-        internal
-        pure
-        returns (PRBMath.SD59x18 memory result)
-    {
-        if (x.value == 0) {
-            return PRBMath.SD59x18({ value: 0 });
+    function gm(PRBMath.SD59x18 x, PRBMath.SD59x18 y) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
+        int256 yValue = PRBMath.SD59x18.unwrap(y);
+        if (xValue == 0) {
+            return PRBMath.SD59x18.wrap(0);
         }
 
         unchecked {
             // Checking for overflow this way is faster than letting Solidity do it.
-            int256 xy = x.value * y.value;
-            if (xy / x.value != y.value) {
-                revert PRBMathSD59x18__GmOverflow(x.value, y.value);
+            int256 xy = xValue * yValue;
+            if (xy / xValue != yValue) {
+                revert PRBMathSD59x18__GmOverflow(xValue, yValue);
             }
 
             // The product cannot be negative.
             if (xy < 0) {
-                revert PRBMathSD59x18__GmNegativeProduct(x.value, y.value);
+                revert PRBMathSD59x18__GmNegativeProduct(xValue, yValue);
             }
 
             // We don't need to multiply by the SCALE here because the x*y product had already picked up a factor of SCALE
             // during multiplication. See the comments within the "sqrt" function.
-            result = PRBMath.SD59x18({ value: int256(PRBMath.sqrt(uint256(xy))) });
+            result = PRBMath.SD59x18.wrap(int256(PRBMath.sqrt(uint256(xy))));
         }
     }
 
@@ -372,10 +358,10 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The signed 59.18-decimal fixed-point number for which to calculate the inverse.
     /// @return result The inverse as a signed 59.18-decimal fixed-point number.
-    function inv(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
+    function inv(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
         unchecked {
             // 1e36 is SCALE * SCALE.
-            result = PRBMath.SD59x18({ value: 1e36 / x.value });
+            result = PRBMath.SD59x18.wrap(1e36 / PRBMath.SD59x18.unwrap(x));
         }
     }
 
@@ -392,12 +378,12 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The signed 59.18-decimal fixed-point number for which to calculate the natural logarithm.
     /// @return result The natural logarithm as a signed 59.18-decimal fixed-point number.
-    function ln(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
+    function ln(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
         // Do the fixed-point multiplication inline to save gas. This is overflow-safe because the maximum value that log2(x)
         // can return is 195205294292027477728.
         unchecked {
-            int256 rValue = (log2(x).value * SCALE) / LOG2_E;
-            result = PRBMath.SD59x18({ value: rValue });
+            int256 rValue = (PRBMath.SD59x18.unwrap(log2(x)) * SCALE) / LOG2_E;
+            result = PRBMath.SD59x18.wrap(rValue);
         }
     }
 
@@ -414,8 +400,8 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The signed 59.18-decimal fixed-point number for which to calculate the common logarithm.
     /// @return result The common logarithm as a signed 59.18-decimal fixed-point number.
-    function log10(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function log10(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
         if (xValue <= 0) {
             revert PRBMathSD59x18__LogInputTooSmall(xValue);
         }
@@ -510,12 +496,12 @@ library PRBMathSD59x18Typed {
         }
 
         if (rValue != MAX_SD59x18) {
-            result = PRBMath.SD59x18({ value: rValue });
+            result = PRBMath.SD59x18.wrap(rValue);
         } else {
             // Do the fixed-point division inline to save gas. The denominator is log2(10).
             unchecked {
-                rValue = (log2(x).value * SCALE) / 3_321928094887362347;
-                result = PRBMath.SD59x18({ value: rValue });
+                rValue = (PRBMath.SD59x18.unwrap(log2(x)) * SCALE) / 3_321928094887362347;
+                result = PRBMath.SD59x18.wrap(rValue);
             }
         }
     }
@@ -533,8 +519,8 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The signed 59.18-decimal fixed-point number for which to calculate the binary logarithm.
     /// @return result The binary logarithm as a signed 59.18-decimal fixed-point number.
-    function log2(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function log2(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
         if (xValue <= 0) {
             revert PRBMathSD59x18__LogInputTooSmall(xValue);
         }
@@ -564,7 +550,7 @@ library PRBMathSD59x18Typed {
 
             // If y = 1, the fractional part is zero.
             if (y == SCALE) {
-                return PRBMath.SD59x18({ value: rValue * sign });
+                return PRBMath.SD59x18.wrap(rValue * sign);
             }
 
             // Calculate the fractional part via the iterative approximation.
@@ -581,7 +567,7 @@ library PRBMathSD59x18Typed {
                     y >>= 1;
                 }
             }
-            result = PRBMath.SD59x18({ value: rValue * sign });
+            result = PRBMath.SD59x18.wrap(rValue * sign);
         }
     }
 
@@ -602,13 +588,9 @@ library PRBMathSD59x18Typed {
     /// @param x The multiplicand as a signed 59.18-decimal fixed-point number.
     /// @param y The multiplier as a signed 59.18-decimal fixed-point number.
     /// @return result The product as a signed 59.18-decimal fixed-point number.
-    function mul(PRBMath.SD59x18 memory x, PRBMath.SD59x18 memory y)
-        internal
-        pure
-        returns (PRBMath.SD59x18 memory result)
-    {
-        int256 xValue = x.value;
-        int256 yValue = y.value;
+    function mul(PRBMath.SD59x18 x, PRBMath.SD59x18 y) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
+        int256 yValue = PRBMath.SD59x18.unwrap(y);
         if (xValue == MIN_SD59x18 || yValue == MIN_SD59x18) {
             revert PRBMathSD59x18__MulInputTooSmall();
         }
@@ -630,13 +612,13 @@ library PRBMathSD59x18Typed {
                 sx := sgt(xValue, sub(0, 1))
                 sy := sgt(yValue, sub(0, 1))
             }
-            result = PRBMath.SD59x18({ value: sx ^ sy == 1 ? -int256(rAbs) : int256(rAbs) });
+            result = PRBMath.SD59x18.wrap(sx ^ sy == 1 ? -int256(rAbs) : int256(rAbs));
         }
     }
 
     /// @notice Returns PI as a signed 59.18-decimal fixed-point number.
-    function pi() internal pure returns (PRBMath.SD59x18 memory result) {
-        result = PRBMath.SD59x18({ value: 3_141592653589793238 });
+    function pi() internal pure returns (PRBMath.SD59x18 result) {
+        result = PRBMath.SD59x18.wrap(3_141592653589793238);
     }
 
     /// @notice Raises x to the power of y.
@@ -654,13 +636,9 @@ library PRBMathSD59x18Typed {
     /// @param x Number to raise to given power y, as a signed 59.18-decimal fixed-point number.
     /// @param y Exponent to raise x to, as a signed 59.18-decimal fixed-point number.
     /// @return result x raised to power y, as a signed 59.18-decimal fixed-point number.
-    function pow(PRBMath.SD59x18 memory x, PRBMath.SD59x18 memory y)
-        internal
-        pure
-        returns (PRBMath.SD59x18 memory result)
-    {
-        if (x.value == 0) {
-            return PRBMath.SD59x18({ value: y.value == 0 ? SCALE : int256(0) });
+    function pow(PRBMath.SD59x18 x, PRBMath.SD59x18 y) internal pure returns (PRBMath.SD59x18 result) {
+        if (PRBMath.SD59x18.unwrap(x) == 0) {
+            return PRBMath.SD59x18.wrap(PRBMath.SD59x18.unwrap(y) == 0 ? SCALE : int256(0));
         } else {
             result = exp2(mul(log2(x), y));
         }
@@ -682,8 +660,8 @@ library PRBMathSD59x18Typed {
     /// @param x The base as a signed 59.18-decimal fixed-point number.
     /// @param y The exponent as an uint256.
     /// @return result The result as a signed 59.18-decimal fixed-point number.
-    function powu(PRBMath.SD59x18 memory x, uint256 y) internal pure returns (PRBMath.SD59x18 memory result) {
-        uint256 xAbs = uint256(abs(x).value);
+    function powu(PRBMath.SD59x18 x, uint256 y) internal pure returns (PRBMath.SD59x18 result) {
+        uint256 xAbs = uint256(PRBMath.SD59x18.unwrap(abs(x)));
 
         // Calculate the first iteration of the loop in advance.
         uint256 rAbs = y & 1 > 0 ? xAbs : uint256(SCALE);
@@ -705,13 +683,13 @@ library PRBMathSD59x18Typed {
         }
 
         // Is the base negative and the exponent an odd number?
-        bool isNegative = x.value < 0 && y & 1 == 1;
-        result = PRBMath.SD59x18({ value: isNegative ? -int256(rAbs) : int256(rAbs) });
+        bool isNegative = PRBMath.SD59x18.unwrap(x) < 0 && y & 1 == 1;
+        result = PRBMath.SD59x18.wrap(isNegative ? -int256(rAbs) : int256(rAbs));
     }
 
     /// @notice Returns 1 as a signed 59.18-decimal fixed-point number.
-    function scale() internal pure returns (PRBMath.SD59x18 memory result) {
-        result = PRBMath.SD59x18({ value: SCALE });
+    function scale() internal pure returns (PRBMath.SD59x18 result) {
+        result = PRBMath.SD59x18.wrap(SCALE);
     }
 
     /// @notice Calculates the square root of x, rounding down.
@@ -723,8 +701,8 @@ library PRBMathSD59x18Typed {
     ///
     /// @param x The signed 59.18-decimal fixed-point number for which to calculate the square root.
     /// @return result The result as a signed 59.18-decimal fixed-point .
-    function sqrt(PRBMath.SD59x18 memory x) internal pure returns (PRBMath.SD59x18 memory result) {
-        int256 xValue = x.value;
+    function sqrt(PRBMath.SD59x18 x) internal pure returns (PRBMath.SD59x18 result) {
+        int256 xValue = PRBMath.SD59x18.unwrap(x);
         unchecked {
             if (xValue < 0) {
                 revert PRBMathSD59x18__SqrtNegativeInput(xValue);
@@ -735,7 +713,7 @@ library PRBMathSD59x18Typed {
             // Multiply x by the SCALE to account for the factor of SCALE that is picked up when multiplying two signed
             // 59.18-decimal fixed-point numbers together (in this case, those two numbers are both the square root).
             int256 rValue = int256(PRBMath.sqrt(uint256(xValue * SCALE)));
-            result = PRBMath.SD59x18({ value: rValue });
+            result = PRBMath.SD59x18.wrap(rValue);
         }
     }
 
@@ -744,20 +722,16 @@ library PRBMathSD59x18Typed {
     /// @param x The minuend as a signed 59.18-decimal fixed-point number.
     /// @param y The subtrahend as a signed 59.18-decimal fixed-point number.
     /// @param result The difference as a signed 59.18 decimal fixed-point number.
-    function sub(PRBMath.SD59x18 memory x, PRBMath.SD59x18 memory y)
-        internal
-        pure
-        returns (PRBMath.SD59x18 memory result)
-    {
-        result = PRBMath.SD59x18({ value: x.value - y.value });
+    function sub(PRBMath.SD59x18 x, PRBMath.SD59x18 y) internal pure returns (PRBMath.SD59x18 result) {
+        result = PRBMath.SD59x18.wrap(PRBMath.SD59x18.unwrap(x) - PRBMath.SD59x18.unwrap(y));
     }
 
     /// @notice Converts a signed 59.18-decimal fixed-point number to basic integer form, rounding down in the process.
     /// @param x The signed 59.18-decimal fixed-point number to convert.
     /// @return result The same number in basic integer form.
-    function toInt(PRBMath.SD59x18 memory x) internal pure returns (int256 result) {
+    function toInt(PRBMath.SD59x18 x) internal pure returns (int256 result) {
         unchecked {
-            result = x.value / SCALE;
+            result = PRBMath.SD59x18.unwrap(x) / SCALE;
         }
     }
 }

--- a/contracts/PRBMathUD60x18Typed.sol
+++ b/contracts/PRBMathUD60x18Typed.sol
@@ -35,17 +35,16 @@ library PRBMathUD60x18Typed {
     /// @param x The first summand as an unsigned 60.18-decimal fixed-point number.
     /// @param y The second summand as an unsigned 60.18-decimal fixed-point number.
     /// @param result The sum as an unsigned 59.18 decimal fixed-point number.
-    function add(PRBMath.UD60x18 memory x, PRBMath.UD60x18 memory y)
-        internal
-        pure
-        returns (PRBMath.UD60x18 memory result)
-    {
+    function add(PRBMath.UD60x18 x, PRBMath.UD60x18 y) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
+        uint256 yValue = PRBMath.UD60x18.unwrap(y);
+
         unchecked {
-            uint256 rValue = x.value + y.value;
-            if (rValue < x.value) {
-                revert PRBMathUD60x18__AddOverflow(x.value, y.value);
+            uint256 rValue = xValue + yValue;
+            if (rValue < xValue) {
+                revert PRBMathUD60x18__AddOverflow(xValue, yValue);
             }
-            result = PRBMath.UD60x18({ value: rValue });
+            result = PRBMath.UD60x18.wrap(rValue);
         }
     }
 
@@ -53,17 +52,16 @@ library PRBMathUD60x18Typed {
     /// @param x The first operand as an unsigned 60.18-decimal fixed-point number.
     /// @param y The second operand as an unsigned 60.18-decimal fixed-point number.
     /// @return result The arithmetic average as an unsigned 60.18-decimal fixed-point number.
-    function avg(PRBMath.UD60x18 memory x, PRBMath.UD60x18 memory y)
-        internal
-        pure
-        returns (PRBMath.UD60x18 memory result)
-    {
+    function avg(PRBMath.UD60x18 x, PRBMath.UD60x18 y) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
+        uint256 yValue = PRBMath.UD60x18.unwrap(y);
+
         // The operations can never overflow.
         unchecked {
             // The last operand checks if both x and y are odd and if that is the case, we add 1 to the result. We need
             // to do this because if both numbers are odd, the 0.5 remainder gets truncated twice.
-            uint256 rValue = (x.value >> 1) + (y.value >> 1) + (x.value & y.value & 1);
-            result = PRBMath.UD60x18({ value: rValue });
+            uint256 rValue = (xValue >> 1) + (yValue >> 1) + (xValue & yValue & 1);
+            result = PRBMath.UD60x18.wrap(rValue);
         }
     }
 
@@ -77,8 +75,8 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The unsigned 60.18-decimal fixed-point number to ceil.
     /// @param result The least integer greater than or equal to x, as an unsigned 60.18-decimal fixed-point number.
-    function ceil(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
-        uint256 xValue = x.value;
+    function ceil(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
         if (xValue > MAX_WHOLE_UD60x18) {
             revert PRBMathUD60x18__CeilOverflow(xValue);
         }
@@ -94,7 +92,7 @@ library PRBMathUD60x18Typed {
             // Equivalent to "x + delta * (remainder > 0 ? 1 : 0)" but faster.
             rValue := add(xValue, mul(delta, gt(remainder, 0)))
         }
-        result = PRBMath.UD60x18({ value: rValue });
+        result = PRBMath.UD60x18.wrap(rValue);
     }
 
     /// @notice Divides two unsigned 60.18-decimal fixed-point numbers, returning a new unsigned 60.18-decimal fixed-point number.
@@ -107,18 +105,14 @@ library PRBMathUD60x18Typed {
     /// @param x The numerator as an unsigned 60.18-decimal fixed-point number.
     /// @param y The denominator as an unsigned 60.18-decimal fixed-point number.
     /// @param result The quotient as an unsigned 60.18-decimal fixed-point number.
-    function div(PRBMath.UD60x18 memory x, PRBMath.UD60x18 memory y)
-        internal
-        pure
-        returns (PRBMath.UD60x18 memory result)
-    {
-        result = PRBMath.UD60x18({ value: PRBMath.mulDiv(x.value, SCALE, y.value) });
+    function div(PRBMath.UD60x18 x, PRBMath.UD60x18 y) internal pure returns (PRBMath.UD60x18 result) {
+        result = PRBMath.UD60x18.wrap(PRBMath.mulDiv(PRBMath.UD60x18.unwrap(x), SCALE, PRBMath.UD60x18.unwrap(y)));
     }
 
     /// @notice Returns Euler's number as an unsigned 60.18-decimal fixed-point number.
     /// @dev See https://en.wikipedia.org/wiki/E_(mathematical_constant).
-    function e() internal pure returns (PRBMath.UD60x18 memory result) {
-        result = PRBMath.UD60x18({ value: 2_718281828459045235 });
+    function e() internal pure returns (PRBMath.UD60x18 result) {
+        result = PRBMath.UD60x18.wrap(2_718281828459045235);
     }
 
     /// @notice Calculates the natural exponent of x.
@@ -131,8 +125,8 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The exponent as an unsigned 60.18-decimal fixed-point number.
     /// @return result The result as an unsigned 60.18-decimal fixed-point number.
-    function exp(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
-        uint256 xValue = x.value;
+    function exp(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
 
         // Without this check, the value passed to "exp2" would be greater than 192.
         if (xValue >= 133_084258667509499441) {
@@ -141,8 +135,8 @@ library PRBMathUD60x18Typed {
 
         // Do the fixed-point multiplication inline to save gas.
         unchecked {
-            uint256 doubleScaleProduct = x.value * LOG2_E;
-            PRBMath.UD60x18 memory exponent = PRBMath.UD60x18({ value: (doubleScaleProduct + HALF_SCALE) / SCALE });
+            uint256 doubleScaleProduct = xValue * LOG2_E;
+            PRBMath.UD60x18 exponent = PRBMath.UD60x18.wrap((doubleScaleProduct + HALF_SCALE) / SCALE);
             result = exp2(exponent);
         }
     }
@@ -157,18 +151,20 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The exponent as an unsigned 60.18-decimal fixed-point number.
     /// @return result The result as an unsigned 60.18-decimal fixed-point number.
-    function exp2(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
+    function exp2(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
+
         // 2^192 doesn't fit within the 192.64-bit format used internally in this function.
-        if (x.value >= 192e18) {
-            revert PRBMathUD60x18__Exp2InputTooBig(x.value);
+        if (xValue >= 192e18) {
+            revert PRBMathUD60x18__Exp2InputTooBig(xValue);
         }
 
         unchecked {
             // Convert x to the 192.64-bit fixed-point format.
-            uint256 x192x64 = (x.value << 64) / SCALE;
+            uint256 x192x64 = (xValue << 64) / SCALE;
 
             // Pass x to the PRBMath.exp2 function, which uses the 192.64-bit fixed-point number representation.
-            result = PRBMath.UD60x18({ value: PRBMath.exp2(x192x64) });
+            result = PRBMath.UD60x18.wrap(PRBMath.exp2(x192x64));
         }
     }
 
@@ -177,8 +173,8 @@ library PRBMathUD60x18Typed {
     /// See https://en.wikipedia.org/wiki/Floor_and_ceiling_functions.
     /// @param x The unsigned 60.18-decimal fixed-point number to floor.
     /// @param result The greatest integer less than or equal to x, as an unsigned 60.18-decimal fixed-point number.
-    function floor(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
-        uint256 xValue = x.value;
+    function floor(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
         uint256 rValue;
         assembly {
             // Equivalent to "x % SCALE" but faster.
@@ -187,20 +183,20 @@ library PRBMathUD60x18Typed {
             // Equivalent to "x - remainder * (remainder > 0 ? 1 : 0)" but faster.
             rValue := sub(xValue, mul(remainder, gt(remainder, 0)))
         }
-        result = PRBMath.UD60x18({ value: rValue });
+        result = PRBMath.UD60x18.wrap(rValue);
     }
 
     /// @notice Yields the excess beyond the floor of x.
     /// @dev Based on the odd function definition https://en.wikipedia.org/wiki/Fractional_part.
     /// @param x The unsigned 60.18-decimal fixed-point number to get the fractional part of.
     /// @param result The fractional part of x as an unsigned 60.18-decimal fixed-point number.
-    function frac(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
-        uint256 xValue = x.value;
+    function frac(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
         uint256 rValue;
         assembly {
             rValue := mod(xValue, SCALE)
         }
-        result = PRBMath.UD60x18({ value: rValue });
+        result = PRBMath.UD60x18.wrap(rValue);
     }
 
     /// @notice Converts a number from basic integer form to unsigned 60.18-decimal fixed-point representation.
@@ -210,12 +206,12 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The basic integer to convert.
     /// @param result The same number in unsigned 60.18-decimal fixed-point representation.
-    function fromUint(uint256 x) internal pure returns (PRBMath.UD60x18 memory result) {
+    function fromUint(uint256 x) internal pure returns (PRBMath.UD60x18 result) {
         unchecked {
             if (x > MAX_UD60x18 / SCALE) {
                 revert PRBMathUD60x18__FromUintOverflow(x);
             }
-            result = PRBMath.UD60x18({ value: x * SCALE });
+            result = PRBMath.UD60x18.wrap(x * SCALE);
         }
     }
 
@@ -227,25 +223,23 @@ library PRBMathUD60x18Typed {
     /// @param x The first operand as an unsigned 60.18-decimal fixed-point number.
     /// @param y The second operand as an unsigned 60.18-decimal fixed-point number.
     /// @return result The result as an unsigned 60.18-decimal fixed-point number.
-    function gm(PRBMath.UD60x18 memory x, PRBMath.UD60x18 memory y)
-        internal
-        pure
-        returns (PRBMath.UD60x18 memory result)
-    {
-        if (x.value == 0) {
-            return PRBMath.UD60x18({ value: 0 });
+    function gm(PRBMath.UD60x18 x, PRBMath.UD60x18 y) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
+        uint256 yValue = PRBMath.UD60x18.unwrap(y);
+        if (xValue == 0) {
+            return PRBMath.UD60x18.wrap(0);
         }
 
         unchecked {
             // Checking for overflow this way is faster than letting Solidity do it.
-            uint256 xy = x.value * y.value;
-            if (xy / x.value != y.value) {
-                revert PRBMathUD60x18__GmOverflow(x.value, y.value);
+            uint256 xy = xValue * yValue;
+            if (xy / xValue != yValue) {
+                revert PRBMathUD60x18__GmOverflow(xValue, yValue);
             }
 
             // We don't need to multiply by the SCALE here because the x*y product had already picked up a factor of SCALE
             // during multiplication. See the comments within the "sqrt" function.
-            result = PRBMath.UD60x18({ value: PRBMath.sqrt(xy) });
+            result = PRBMath.UD60x18.wrap(PRBMath.sqrt(xy));
         }
     }
 
@@ -256,10 +250,10 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The unsigned 60.18-decimal fixed-point number for which to calculate the inverse.
     /// @return result The inverse as an unsigned 60.18-decimal fixed-point number.
-    function inv(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
+    function inv(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
         unchecked {
             // 1e36 is SCALE * SCALE.
-            result = PRBMath.UD60x18({ value: 1e36 / x.value });
+            result = PRBMath.UD60x18.wrap(1e36 / PRBMath.UD60x18.unwrap(x));
         }
     }
 
@@ -276,12 +270,12 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The unsigned 60.18-decimal fixed-point number for which to calculate the natural logarithm.
     /// @return result The natural logarithm as an unsigned 60.18-decimal fixed-point number.
-    function ln(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
+    function ln(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
         // Do the fixed-point multiplication inline to save gas. This is overflow-safe because the maximum value that log2(x)
         // can return is 196205294292027477728.
         unchecked {
-            uint256 rValue = (log2(x).value * SCALE) / LOG2_E;
-            result = PRBMath.UD60x18({ value: rValue });
+            uint256 rValue = (PRBMath.UD60x18.unwrap(log2(x)) * SCALE) / LOG2_E;
+            result = PRBMath.UD60x18.wrap(rValue);
         }
     }
 
@@ -298,8 +292,8 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The unsigned 60.18-decimal fixed-point number for which to calculate the common logarithm.
     /// @return result The common logarithm as an unsigned 60.18-decimal fixed-point number.
-    function log10(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
-        uint256 xValue = x.value;
+    function log10(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
         if (xValue < SCALE) {
             revert PRBMathUD60x18__LogInputTooSmall(xValue);
         }
@@ -395,12 +389,12 @@ library PRBMathUD60x18Typed {
         }
 
         if (rValue != MAX_UD60x18) {
-            result = PRBMath.UD60x18({ value: rValue });
+            result = PRBMath.UD60x18.wrap(rValue);
         } else {
             // Do the fixed-point division inline to save gas. The denominator is log2(10).
             unchecked {
-                rValue = (log2(x).value * SCALE) / 3_321928094887362347;
-                result = PRBMath.UD60x18({ value: rValue });
+                rValue = (PRBMath.UD60x18.unwrap(log2(x)) * SCALE) / 3_321928094887362347;
+                result = PRBMath.UD60x18.wrap(rValue);
             }
         }
     }
@@ -418,8 +412,8 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The unsigned 60.18-decimal fixed-point number for which to calculate the binary logarithm.
     /// @return result The binary logarithm as an unsigned 60.18-decimal fixed-point number.
-    function log2(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
-        uint256 xValue = x.value;
+    function log2(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
         if (xValue < SCALE) {
             revert PRBMathUD60x18__LogInputTooSmall(xValue);
         }
@@ -436,7 +430,7 @@ library PRBMathUD60x18Typed {
 
             // If y = 1, the fractional part is zero.
             if (y == SCALE) {
-                return PRBMath.UD60x18({ value: rValue });
+                return PRBMath.UD60x18.wrap(rValue);
             }
 
             // Calculate the fractional part via the iterative approximation.
@@ -453,7 +447,7 @@ library PRBMathUD60x18Typed {
                     y >>= 1;
                 }
             }
-            result = PRBMath.UD60x18({ value: rValue });
+            result = PRBMath.UD60x18.wrap(rValue);
         }
     }
 
@@ -463,17 +457,13 @@ library PRBMathUD60x18Typed {
     /// @param x The multiplicand as an unsigned 60.18-decimal fixed-point number.
     /// @param y The multiplier as an unsigned 60.18-decimal fixed-point number.
     /// @return result The product as an unsigned 60.18-decimal fixed-point number.
-    function mul(PRBMath.UD60x18 memory x, PRBMath.UD60x18 memory y)
-        internal
-        pure
-        returns (PRBMath.UD60x18 memory result)
-    {
-        result = PRBMath.UD60x18({ value: PRBMath.mulDivFixedPoint(x.value, y.value) });
+    function mul(PRBMath.UD60x18 x, PRBMath.UD60x18 y) internal pure returns (PRBMath.UD60x18 result) {
+        result = PRBMath.UD60x18.wrap(PRBMath.mulDivFixedPoint(PRBMath.UD60x18.unwrap(x), PRBMath.UD60x18.unwrap(y)));
     }
 
     /// @notice Returns PI as an unsigned 60.18-decimal fixed-point number.
-    function pi() internal pure returns (PRBMath.UD60x18 memory result) {
-        result = PRBMath.UD60x18({ value: 3_141592653589793238 });
+    function pi() internal pure returns (PRBMath.UD60x18 result) {
+        result = PRBMath.UD60x18.wrap(3_141592653589793238);
     }
 
     /// @notice Raises x to the power of y.
@@ -490,13 +480,9 @@ library PRBMathUD60x18Typed {
     /// @param x Number to raise to given power y, as an unsigned 60.18-decimal fixed-point number.
     /// @param y Exponent to raise x to, as an unsigned 60.18-decimal fixed-point number.
     /// @return result x raised to power y, as an unsigned 60.18-decimal fixed-point number.
-    function pow(PRBMath.UD60x18 memory x, PRBMath.UD60x18 memory y)
-        internal
-        pure
-        returns (PRBMath.UD60x18 memory result)
-    {
-        if (x.value == 0) {
-            return PRBMath.UD60x18({ value: y.value == 0 ? SCALE : uint256(0) });
+    function pow(PRBMath.UD60x18 x, PRBMath.UD60x18 y) internal pure returns (PRBMath.UD60x18 result) {
+        if (PRBMath.UD60x18.unwrap(x) == 0) {
+            return PRBMath.UD60x18.wrap(PRBMath.UD60x18.unwrap(y) == 0 ? SCALE : uint256(0));
         } else {
             result = exp2(mul(log2(x), y));
         }
@@ -517,9 +503,9 @@ library PRBMathUD60x18Typed {
     /// @param x The base as an unsigned 60.18-decimal fixed-point number.
     /// @param y The exponent as an uint256.
     /// @return result The result as an unsigned 60.18-decimal fixed-point number.
-    function powu(PRBMath.UD60x18 memory x, uint256 y) internal pure returns (PRBMath.UD60x18 memory result) {
+    function powu(PRBMath.UD60x18 x, uint256 y) internal pure returns (PRBMath.UD60x18 result) {
         // Calculate the first iteration of the loop in advance.
-        uint256 xValue = x.value;
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
         uint256 rValue = y & 1 > 0 ? xValue : SCALE;
 
         // Equivalent to "for(y /= 2; y > 0; y /= 2)" but faster.
@@ -531,12 +517,12 @@ library PRBMathUD60x18Typed {
                 rValue = PRBMath.mulDivFixedPoint(rValue, xValue);
             }
         }
-        result = PRBMath.UD60x18({ value: rValue });
+        result = PRBMath.UD60x18.wrap(rValue);
     }
 
     /// @notice Returns 1 as an unsigned 60.18-decimal fixed-point number.
-    function scale() internal pure returns (PRBMath.UD60x18 memory result) {
-        result = PRBMath.UD60x18({ value: SCALE });
+    function scale() internal pure returns (PRBMath.UD60x18 result) {
+        result = PRBMath.UD60x18.wrap(SCALE);
     }
 
     /// @notice Calculates the square root of x, rounding down.
@@ -547,14 +533,15 @@ library PRBMathUD60x18Typed {
     ///
     /// @param x The unsigned 60.18-decimal fixed-point number for which to calculate the square root.
     /// @return result The result as an unsigned 60.18-decimal fixed-point .
-    function sqrt(PRBMath.UD60x18 memory x) internal pure returns (PRBMath.UD60x18 memory result) {
+    function sqrt(PRBMath.UD60x18 x) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
         unchecked {
-            if (x.value > MAX_UD60x18 / SCALE) {
-                revert PRBMathUD60x18__SqrtOverflow(x.value);
+            if (xValue > MAX_UD60x18 / SCALE) {
+                revert PRBMathUD60x18__SqrtOverflow(xValue);
             }
             // Multiply x by the SCALE to account for the factor of SCALE that is picked up when multiplying two unsigned
             // 60.18-decimal fixed-point numbers together (in this case, those two numbers are both the square root).
-            result = PRBMath.UD60x18({ value: PRBMath.sqrt(x.value * SCALE) });
+            result = PRBMath.UD60x18.wrap(PRBMath.sqrt(xValue * SCALE));
         }
     }
 
@@ -563,25 +550,23 @@ library PRBMathUD60x18Typed {
     /// @param x The minuend as an unsigned 60.18-decimal fixed-point number.
     /// @param y The subtrahend as an unsigned 60.18-decimal fixed-point number.
     /// @param result The difference as an unsigned 60.18 decimal fixed-point number.
-    function sub(PRBMath.UD60x18 memory x, PRBMath.UD60x18 memory y)
-        internal
-        pure
-        returns (PRBMath.UD60x18 memory result)
-    {
+    function sub(PRBMath.UD60x18 x, PRBMath.UD60x18 y) internal pure returns (PRBMath.UD60x18 result) {
+        uint256 xValue = PRBMath.UD60x18.unwrap(x);
+        uint256 yValue = PRBMath.UD60x18.unwrap(y);
         unchecked {
-            if (x.value < y.value) {
-                revert PRBMathUD60x18__SubUnderflow(x.value, y.value);
+            if (xValue < yValue) {
+                revert PRBMathUD60x18__SubUnderflow(xValue, yValue);
             }
-            result = PRBMath.UD60x18({ value: x.value - y.value });
+            result = PRBMath.UD60x18.wrap(xValue - yValue);
         }
     }
 
     /// @notice Converts a unsigned 60.18-decimal fixed-point number to basic integer form, rounding down in the process.
     /// @param x The unsigned 60.18-decimal fixed-point number to convert.
     /// @return result The same number in basic integer form.
-    function toUint(PRBMath.UD60x18 memory x) internal pure returns (uint256 result) {
+    function toUint(PRBMath.UD60x18 x) internal pure returns (uint256 result) {
         unchecked {
-            result = x.value / SCALE;
+            result = PRBMath.UD60x18.unwrap(x) / SCALE;
         }
     }
 }

--- a/contracts/test/PRBMathSD59x18TypedMock.sol
+++ b/contracts/test/PRBMathSD59x18TypedMock.sol
@@ -6,125 +6,125 @@ import "../PRBMathSD59x18Typed.sol";
 
 contract PRBMathSD59x18TypedMock {
     function doAbs(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.abs(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.abs(xsd));
     }
 
     function doAdd(int256 x, int256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        PRBMath.SD59x18 memory ysd = PRBMath.SD59x18({ value: y });
-        result = PRBMathSD59x18Typed.add(xsd, ysd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        PRBMath.SD59x18 ysd = PRBMath.SD59x18.wrap(y);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.add(xsd, ysd));
     }
 
     function doAvg(int256 x, int256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        PRBMath.SD59x18 memory ysd = PRBMath.SD59x18({ value: y });
-        result = PRBMathSD59x18Typed.avg(xsd, ysd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        PRBMath.SD59x18 ysd = PRBMath.SD59x18.wrap(y);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.avg(xsd, ysd));
     }
 
     function doCeil(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.ceil(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.ceil(xsd));
     }
 
     function doDiv(int256 x, int256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        PRBMath.SD59x18 memory ysd = PRBMath.SD59x18({ value: y });
-        result = PRBMathSD59x18Typed.div(xsd, ysd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        PRBMath.SD59x18 ysd = PRBMath.SD59x18.wrap(y);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.div(xsd, ysd));
     }
 
     function doExp(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.exp(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.exp(xsd));
     }
 
     function doExp2(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.exp2(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.exp2(xsd));
     }
 
     function doFloor(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.floor(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.floor(xsd));
     }
 
     function doFrac(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.frac(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.frac(xsd));
     }
 
     function doFromInt(int256 x) external pure returns (int256 result) {
-        result = PRBMathSD59x18Typed.fromInt(x).value;
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.fromInt(x));
     }
 
     function doGm(int256 x, int256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        PRBMath.SD59x18 memory ysd = PRBMath.SD59x18({ value: y });
-        result = PRBMathSD59x18Typed.gm(xsd, ysd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        PRBMath.SD59x18 ysd = PRBMath.SD59x18.wrap(y);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.gm(xsd, ysd));
     }
 
     function doInv(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.inv(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.inv(xsd));
     }
 
     function doLn(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.ln(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.ln(xsd));
     }
 
     function doLog10(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.log10(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.log10(xsd));
     }
 
     function doLog2(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.log2(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.log2(xsd));
     }
 
     function doMul(int256 x, int256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        PRBMath.SD59x18 memory ysd = PRBMath.SD59x18({ value: y });
-        result = PRBMathSD59x18Typed.mul(xsd, ysd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        PRBMath.SD59x18 ysd = PRBMath.SD59x18.wrap(y);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.mul(xsd, ysd));
     }
 
     function doPow(int256 x, int256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        PRBMath.SD59x18 memory ysd = PRBMath.SD59x18({ value: y });
-        result = PRBMathSD59x18Typed.pow(xsd, ysd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        PRBMath.SD59x18 ysd = PRBMath.SD59x18.wrap(y);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.pow(xsd, ysd));
     }
 
     function doPowu(int256 x, uint256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.powu(xsd, y).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.powu(xsd, y));
     }
 
     function doSqrt(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        result = PRBMathSD59x18Typed.sqrt(xsd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.sqrt(xsd));
     }
 
     function doSub(int256 x, int256 y) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
-        PRBMath.SD59x18 memory ysd = PRBMath.SD59x18({ value: y });
-        result = PRBMathSD59x18Typed.sub(xsd, ysd).value;
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
+        PRBMath.SD59x18 ysd = PRBMath.SD59x18.wrap(y);
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.sub(xsd, ysd));
     }
 
     function doToInt(int256 x) external pure returns (int256 result) {
-        PRBMath.SD59x18 memory xsd = PRBMath.SD59x18({ value: x });
+        PRBMath.SD59x18 xsd = PRBMath.SD59x18.wrap(x);
         result = PRBMathSD59x18Typed.toInt(xsd);
     }
 
     function getE() external pure returns (int256 result) {
-        result = PRBMathSD59x18Typed.e().value;
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.e());
     }
 
     function getPi() external pure returns (int256 result) {
-        result = PRBMathSD59x18Typed.pi().value;
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.pi());
     }
 
     function getScale() external pure returns (int256 result) {
-        result = PRBMathSD59x18Typed.scale().value;
+        result = PRBMath.SD59x18.unwrap(PRBMathSD59x18Typed.scale());
     }
 }

--- a/contracts/test/PRBMathUD60x18TypedMock.sol
+++ b/contracts/test/PRBMathUD60x18TypedMock.sol
@@ -6,120 +6,120 @@ import "../PRBMathUD60x18Typed.sol";
 
 contract PRBMathUD60x18TypedMock {
     function doAdd(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        PRBMath.UD60x18 memory yud = PRBMath.UD60x18({ value: y });
-        result = PRBMathUD60x18Typed.add(xud, yud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        PRBMath.UD60x18 yud = PRBMath.UD60x18.wrap(y);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.add(xud, yud));
     }
 
     function doAvg(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        PRBMath.UD60x18 memory yud = PRBMath.UD60x18({ value: y });
-        result = PRBMathUD60x18Typed.avg(xud, yud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        PRBMath.UD60x18 yud = PRBMath.UD60x18.wrap(y);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.avg(xud, yud));
     }
 
     function doCeil(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.ceil(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.ceil(xud));
     }
 
     function doDiv(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        PRBMath.UD60x18 memory yud = PRBMath.UD60x18({ value: y });
-        result = PRBMathUD60x18Typed.div(xud, yud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        PRBMath.UD60x18 yud = PRBMath.UD60x18.wrap(y);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.div(xud, yud));
     }
 
     function doExp(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.exp(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.exp(xud));
     }
 
     function doExp2(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.exp2(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.exp2(xud));
     }
 
     function doFloor(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.floor(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.floor(xud));
     }
 
     function doFrac(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.frac(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.frac(xud));
     }
 
     function doFromUint(uint256 x) external pure returns (uint256 result) {
-        result = PRBMathUD60x18Typed.fromUint(x).value;
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.fromUint(x));
     }
 
     function doGm(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        PRBMath.UD60x18 memory yud = PRBMath.UD60x18({ value: y });
-        result = PRBMathUD60x18Typed.gm(xud, yud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        PRBMath.UD60x18 yud = PRBMath.UD60x18.wrap(y);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.gm(xud, yud));
     }
 
     function doInv(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.inv(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.inv(xud));
     }
 
     function doLn(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.ln(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.ln(xud));
     }
 
     function doLog10(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.log10(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.log10(xud));
     }
 
     function doLog2(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.log2(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.log2(xud));
     }
 
     function doMul(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        PRBMath.UD60x18 memory yud = PRBMath.UD60x18({ value: y });
-        result = PRBMathUD60x18Typed.mul(xud, yud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        PRBMath.UD60x18 yud = PRBMath.UD60x18.wrap(y);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.mul(xud, yud));
     }
 
     function doPow(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        PRBMath.UD60x18 memory yud = PRBMath.UD60x18({ value: y });
-        result = PRBMathUD60x18Typed.pow(xud, yud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        PRBMath.UD60x18 yud = PRBMath.UD60x18.wrap(y);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.pow(xud, yud));
     }
 
     function doPowu(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.powu(xud, y).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.powu(xud, y));
     }
 
     function doSqrt(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        result = PRBMathUD60x18Typed.sqrt(xud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.sqrt(xud));
     }
 
     function doSub(uint256 x, uint256 y) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
-        PRBMath.UD60x18 memory yud = PRBMath.UD60x18({ value: y });
-        result = PRBMathUD60x18Typed.sub(xud, yud).value;
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
+        PRBMath.UD60x18 yud = PRBMath.UD60x18.wrap(y);
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.sub(xud, yud));
     }
 
     function doToUint(uint256 x) external pure returns (uint256 result) {
-        PRBMath.UD60x18 memory xud = PRBMath.UD60x18({ value: x });
+        PRBMath.UD60x18 xud = PRBMath.UD60x18.wrap(x);
         result = PRBMathUD60x18Typed.toUint(xud);
     }
 
     function getE() external pure returns (uint256 result) {
-        result = PRBMathUD60x18Typed.e().value;
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.e());
     }
 
     function getPi() external pure returns (uint256 result) {
-        result = PRBMathUD60x18Typed.pi().value;
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.pi());
     }
 
     function getScale() external pure returns (uint256 result) {
-        result = PRBMathUD60x18Typed.scale().value;
+        result = PRBMath.UD60x18.unwrap(PRBMathUD60x18Typed.scale());
     }
 }


### PR DESCRIPTION
UDVT feels like a better option then struct for typed fixed point arithmetic.

[This would allow setting global "using for"](https://chriseth.github.io/notes/talks/summit_2022/#/9) and soon [operator overloading](https://chriseth.github.io/notes/talks/summit_2022/#/10)