### PR TITLE
docs: reflect correct paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ refer to the source code, which is well-documented with NatSpec comments.
 | `sd`          | Wraps a simple integer into SD59x18                                   |
 | `sd59x18`     | Wraps a simple integer into SD59x18                                   |
 | `toSD59x18`   | Converts a simple integer to SD59x18 by multiplying it by 1e18        |
-| `toSD60x18`   | Converts a simple integer to UD60x18 by multiplying it by 1e18        |
+| `toUD60x18`   | Converts a simple integer to UD60x18 by multiplying it by 1e18        |
 | `ud`          | Wraps a simple integer into UD60x18                                   |
 | `ud60x18`     | Wraps a simple integer into UD60x18                                   |
 | `unwrap`      | Unwrap an SD59x18 or UD60x18 number into a simple integer             |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ forge install --no-commit paulrberg/prb-math@v3
 Then, add this to your `remappings.txt` file:
 
 ```text
-@prb/=lib/prb-math/src/
+@prb/math/=lib/prb-math/src/
 ```
 
 ### Node.js
@@ -69,8 +69,8 @@ It is recommended that you import PRBMath in the global scope, because you will 
 ```solidity
 pragma solidity >=0.8.13;
 
-import "@prb/SD59x18.sol";
-import "@prb/UD60x18.sol";
+import "@prb/math/SD59x18.sol";
+import "@prb/math/UD60x18.sol";
 
 ```
 
@@ -82,7 +82,7 @@ Note that PRBMath can only be used in [Solidity v0.8.13](https://blog.solidityla
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import "@prb/SD59x18.sol";
+import "@prb/math/SD59x18.sol";
 
 contract SignedConsumer {
   /// @notice Calculates 5% of the given signed number.
@@ -107,7 +107,7 @@ contract SignedConsumer {
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import "@prb/UD60x18.sol";
+import "@prb/math/UD60x18.sol";
 
 contract UnsignedConsumer {
   /// @notice Calculates 5% of the given signed number.
@@ -181,7 +181,7 @@ However, you should note that using these functions instead of the vanilla opera
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import "@prb/UD60x18.sol";
+import "@prb/math/UD60x18.sol";
 
 function addRshiftEq() pure returns (bool result) {
   UD60x18 x = ud(1e18);
@@ -201,9 +201,9 @@ Foundry. This is useful if, for example, you would like to assert that two SD59x
 ```solidity
 pragma solidity >=0.8.13;
 
-import "@prb/UD60x18.sol";
-import { Assertions as PRBMathAssertions } from "@prb/test/Assertions.sol";
-import { PRBTest } from "@prb/test/PRBTest.sol";
+import "@prb/math/UD60x18.sol";
+import { Assertions as PRBMathAssertions } from "@prb/math/test/Assertions.sol";
+import { PRBTest } from "@prb/math/test/PRBTest.sol";
 
 contract MyTest is PRBTest, PRBMathAssertions {
   function testAdd() external {

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ forge install --no-commit paulrberg/prb-math@v3
 Then, add this to your `remappings.txt` file:
 
 ```text
-prb-math/=lib/prb-math/src/
+@prb/=lib/prb-math/src/
 ```
 
 ### Node.js
@@ -69,8 +69,8 @@ It is recommended that you import PRBMath in the global scope, because you will 
 ```solidity
 pragma solidity >=0.8.13;
 
-import "@prb/math/SD59x18.sol";
-import "@prb/math/UD60x18.sol";
+import "@prb/SD59x18.sol";
+import "@prb/UD60x18.sol";
 
 ```
 
@@ -82,7 +82,7 @@ Note that PRBMath can only be used in [Solidity v0.8.13](https://blog.solidityla
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import "@prb/math/SD59x18.sol";
+import "@prb/SD59x18.sol";
 
 contract SignedConsumer {
   /// @notice Calculates 5% of the given signed number.
@@ -107,7 +107,7 @@ contract SignedConsumer {
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import "@prb/math/UD60x18.sol";
+import "@prb/UD60x18.sol";
 
 contract UnsignedConsumer {
   /// @notice Calculates 5% of the given signed number.
@@ -162,7 +162,7 @@ refer to the source code, which is well-documented with NatSpec comments.
 | `sd`          | Wraps a simple integer into SD59x18                                   |
 | `sd59x18`     | Wraps a simple integer into SD59x18                                   |
 | `toSD59x18`   | Converts a simple integer to SD59x18 by multiplying it by 1e18        |
-| `toSD59x18`   | Converts a simple integer to UD60x18 by multiplying it by 1e18        |
+| `toSD60x18`   | Converts a simple integer to UD60x18 by multiplying it by 1e18        |
 | `ud`          | Wraps a simple integer into UD60x18                                   |
 | `ud60x18`     | Wraps a simple integer into UD60x18                                   |
 | `unwrap`      | Unwrap an SD59x18 or UD60x18 number into a simple integer             |
@@ -181,7 +181,7 @@ However, you should note that using these functions instead of the vanilla opera
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.13;
 
-import "@prb/math/UD60x18.sol";
+import "@prb/UD60x18.sol";
 
 function addRshiftEq() pure returns (bool result) {
   UD60x18 x = ud(1e18);
@@ -201,8 +201,8 @@ Foundry. This is useful if, for example, you would like to assert that two SD59x
 ```solidity
 pragma solidity >=0.8.13;
 
-import "@prb/math/UD60x18.sol";
-import { Assertions as PRBMathAssertions } from "prb-math/test/Assertions.sol";
+import "@prb/UD60x18.sol";
+import { Assertions as PRBMathAssertions } from "@prb/test/Assertions.sol";
 import { PRBTest } from "@prb/test/PRBTest.sol";
 
 contract MyTest is PRBTest, PRBMathAssertions {


### PR DESCRIPTION
Not 100% sure you want these paths remove the `/math/` directory, but I'm migrating a smart contract and I needed to make these fixes.