### PR TITLE
Add unary minus operator for SD59x18

### DIFF
--- a/src/sd59x18/Helpers.sol
+++ b/src/sd59x18/Helpers.sol
@@ -84,6 +84,11 @@ function sub(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
     result = wrap(x.unwrap() - y.unwrap());
 }
 
+/// @notice Implements the checked unary minus operation (-) in the SD59x18 type.
+function unary(SD59x18 x) pure returns (SD59x18 result) {
+    result = wrap(-x.unwrap());
+}
+
 /// @notice Implements the unchecked addition operation (+) in the SD59x18 type.
 function uncheckedAdd(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
     unchecked {

--- a/src/sd59x18/ValueType.sol
+++ b/src/sd59x18/ValueType.sol
@@ -95,5 +95,6 @@ using {
     Helpers.not as ~,
     Helpers.or as |,
     Helpers.sub as -,
+    Helpers.unary as -,
     Helpers.xor as ^
 } for SD59x18 global;

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -27,14 +27,14 @@ abstract contract Base_Test is PRBTest, StdCheats, PRBMathAssertions, PRBMathUti
                                      CONSTANTS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev The minimum value an uint128 number can have.
-    uint128 internal constant MIN_UINT128 = type(uint128).min;
-
     /// @dev The maximum value an uint128 number can have.
     uint128 internal constant MAX_UINT128 = type(uint128).max;
 
     /// @dev The maximum value an uint40 number can have.
     uint128 internal constant MAX_UINT40 = type(uint40).max;
+
+    /// @dev The minimum value an int256 number can have.
+    int256 internal constant MIN_INT256 = type(int256).min;
 
     /*//////////////////////////////////////////////////////////////////////////
                                   TESTING VARIABLES

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -27,6 +27,9 @@ abstract contract Base_Test is PRBTest, StdCheats, PRBMathAssertions, PRBMathUti
                                      CONSTANTS
     //////////////////////////////////////////////////////////////////////////*/
 
+    /// @dev The minimum value an uint128 number can have.
+    uint128 internal constant MIN_UINT128 = type(uint128).min;
+
     /// @dev The maximum value an uint128 number can have.
     uint128 internal constant MAX_UINT128 = type(uint128).max;
 

--- a/test/sd59x18/helpers/Helpers.t.sol
+++ b/test/sd59x18/helpers/Helpers.t.sol
@@ -19,6 +19,7 @@ import {
     or,
     rshift,
     sub,
+    unary,
     uncheckedAdd,
     uncheckedSub,
     uncheckedUnary,
@@ -126,6 +127,15 @@ contract Helpers_Test is SD59x18_Test {
         SD59x18 expected = sd(x - y);
         assertEq(sub(sd(x), sd(y)), expected);
         assertEq(sd(x) - sd(y), expected);
+    }
+
+    function testFuzz_Unary(int256 x) external {
+        // Set the lower bound to MIN_INT256 + 1 to avoid overflow, as absolute value of MIN_INT256 would be 1 unit larger than
+        // MAX_INT256.
+        x = bound(x, MIN_INT256 + 1, MAX_INT256);
+        SD59x18 expected = sd(-x);
+        assertEq(unary(sd(x)), expected);
+        assertEq(-sd(x), expected);
     }
 
     function testFuzz_UncheckedAdd(int256 x, int256 y) external {

--- a/test/sd59x18/helpers/Helpers.t.sol
+++ b/test/sd59x18/helpers/Helpers.t.sol
@@ -32,8 +32,8 @@ import { SD59x18_Test } from "../SD59x18.t.sol";
 
 /// @dev Collection of tests for the helpers functions available in the SD59x18 type.
 contract Helpers_Test is SD59x18_Test {
-    int256 internal constant HALF_MAX_INT256 = type(int256).max / 2;
-    int256 internal constant HALF_MIN_INT256 = type(int256).min / 2;
+    int256 internal constant HALF_MAX_INT256 = MAX_INT256 / 2;
+    int256 internal constant HALF_MIN_INT256 = MIN_INT256 / 2;
 
     function testFuzz_Add(int256 x, int256 y) external {
         x = bound(x, HALF_MIN_INT256, HALF_MAX_INT256);
@@ -130,8 +130,7 @@ contract Helpers_Test is SD59x18_Test {
     }
 
     function testFuzz_Unary(int256 x) external {
-        // Set the lower bound to MIN_INT256 + 1 to avoid overflow, as absolute value of MIN_INT256 would be 1 unit larger than
-        // MAX_INT256.
+        // Cannot take unary of MIN_INT256, because its absolute value would be 1 unit larger than MAX_INT256.
         x = bound(x, MIN_INT256 + 1, MAX_INT256);
         SD59x18 expected = sd(-x);
         assertEq(unary(sd(x)), expected);


### PR DESCRIPTION
This adds ability to directly use `-x` on an `SD59x18`.