### PR TITLE
feat: expand domain of "pow"

### DIFF
--- a/test/ud60x18/math/pow/pow.t.sol
+++ b/test/ud60x18/math/pow/pow.t.sol
@@ -2,119 +2,75 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { ud } from "src/ud60x18/Casting.sol";
-import { E, PI, ZERO } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Exp2_InputTooBig, PRBMath_UD60x18_Log_InputTooSmall } from "src/ud60x18/Errors.sol";
+import { E, PI, UNIT, ZERO } from "src/ud60x18/Constants.sol";
 import { pow } from "src/ud60x18/Math.sol";
 import { UD60x18 } from "src/ud60x18/ValueType.sol";
 
 import { UD60x18_Test } from "../../UD60x18.t.sol";
 
-contract PowTest is UD60x18_Test {
-    UD60x18 internal constant MAX_PERMITTED = UD60x18.wrap(2 ** 192 * 10 ** 18 - 1);
+contract Pow_Test is UD60x18_Test {
+    modifier baseZero() {
+        _;
+    }
 
-    function test_Pow_BaseAndExponentZero() external {
+    function test_Pow_ExponentZero() external baseZero {
         UD60x18 x = ZERO;
         UD60x18 y = ZERO;
         UD60x18 actual = pow(x, y);
-        UD60x18 expected = ud(1e18);
+        UD60x18 expected = UNIT;
         assertEq(actual, expected);
     }
 
-    function baseZeroExponentNotZero_Sets() internal returns (Set[] memory) {
-        delete sets;
-        sets.push(set({ x: 0, y: 1e18, expected: 0 }));
-        sets.push(set({ x: 0, y: E, expected: 0 }));
-        sets.push(set({ x: 0, y: PI, expected: 0 }));
-        return sets;
-    }
-
-    function test_Pow_BaseZeroExponentNotZero() external parameterizedTest(baseZeroExponentNotZero_Sets()) {
-        UD60x18 actual = pow(s.x, s.y);
-        assertEq(actual, s.expected);
+    function testFuzz_Pow_ExponentNotZero(UD60x18 y) external baseZero {
+        vm.assume(y != ZERO);
+        UD60x18 x = ZERO;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected);
     }
 
     modifier whenBaseNotZero() {
         _;
     }
 
-    function test_RevertWhen_BaseLessThanOne() external whenBaseNotZero {
-        UD60x18 x = ud(1e18 - 1);
-        UD60x18 y = PI;
-        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Log_InputTooSmall.selector, x));
-        pow(x, y);
+    function testFuzz_Pow_BaseUnit(UD60x18 y) external whenBaseNotZero {
+        UD60x18 x = UNIT;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected);
     }
 
-    modifier whenBaseGreaterThanOrEqualToOne() {
+    modifier whenBaseNotUnit() {
         _;
     }
 
-    function exponentZero_Sets() internal returns (Set[] memory) {
-        delete sets;
-        sets.push(set({ x: 1e18, y: 0, expected: 1e18 }));
-        sets.push(set({ x: E, y: 0, expected: 1e18 }));
-        sets.push(set({ x: PI, y: 0, expected: 1e18 }));
-        return sets;
-    }
-
-    function test_Pow_ExponentZero()
-        external
-        parameterizedTest(exponentZero_Sets())
-        whenBaseNotZero
-        whenBaseGreaterThanOrEqualToOne
-    {
-        UD60x18 actual = pow(s.x, s.y);
-        assertEq(actual, s.expected);
+    function testFuzz_Pow_ExponentZero(UD60x18 x) external whenBaseNotZero whenBaseNotUnit {
+        vm.assume(x != ZERO && x != UNIT);
+        UD60x18 y = ZERO;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected);
     }
 
     modifier whenExponentNotZero() {
         _;
     }
 
-    function exponentOne_Sets() internal returns (Set[] memory) {
-        delete sets;
-        sets.push(set({ x: 1e18, y: 1e18, expected: 1e18 }));
-        sets.push(set({ x: E, y: 1e18, expected: E }));
-        sets.push(set({ x: PI, y: 1e18, expected: PI }));
-        return sets;
+    function testFuzz_Pow_ExponentUnit(UD60x18 x) external whenBaseNotZero whenBaseNotUnit whenExponentNotZero {
+        vm.assume(x != ZERO && x != UNIT);
+        UD60x18 y = UNIT;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = x;
+        assertEq(actual, expected);
     }
 
-    function test_Pow_ExponentOne()
-        external
-        parameterizedTest(exponentOne_Sets())
-        whenBaseNotZero
-        whenBaseGreaterThanOrEqualToOne
-        whenExponentNotZero
-        whenExponentLessThanOrEqualToMaxPermitted
-    {
-        UD60x18 actual = pow(s.x, s.y);
-        assertEq(actual, s.expected);
-    }
-
-    modifier whenExponentNotOne() {
+    modifier whenExponentNotUnit() {
         _;
     }
 
-    function test_RevertWhen_ExponentGreaterThanOrEqualToMaxPermitted()
-        external
-        whenBaseNotZero
-        whenBaseGreaterThanOrEqualToOne
-        whenExponentNotZero
-        whenExponentNotOne
-    {
-        UD60x18 x = MAX_PERMITTED.add(ud(1));
-        UD60x18 y = ud(1e18 + 1);
-        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Exp2_InputTooBig.selector, ud(192e18 + 192)));
-        pow(x, y);
-    }
-
-    modifier whenExponentLessThanOrEqualToMaxPermitted() {
-        _;
-    }
-
-    function pow_Sets() internal returns (Set[] memory) {
+    function baseGreaterThanUnit_Sets() internal returns (Set[] memory) {
         delete sets;
-        sets.push(set({ x: 1e18, y: 2e18, expected: 1e18 }));
-        sets.push(set({ x: 1e18, y: PI, expected: 1e18 }));
+        sets.push(set({ x: 1e18 + 1, y: 2e18, expected: 1e18 }));
         sets.push(set({ x: 2e18, y: 1.5e18, expected: 2_828427124746190097 }));
         sets.push(set({ x: E, y: 1.66976e18, expected: 5_310893029888037560 }));
         sets.push(set({ x: E, y: E, expected: 15_154262241479263793 }));
@@ -131,17 +87,48 @@ contract PowTest is UD60x18_Test {
                 expected: 340282366920938487757736552507248225013_000000000004316573
             })
         );
-        sets.push(set({ x: MAX_PERMITTED, y: 1e18 - 1, expected: 6277101735386679823624773486129835356722228023657461399187e18 }));
+        sets.push(
+            set({ x: 2 ** 192 * 1e18 - 1, y: 1e18 - 1, expected: 6277101735386679823624773486129835356722228023657461399187e18 })
+        );
         return sets;
     }
 
-    function test_Pow()
+    function test_Pow_BaseGreaterThanUnit()
         external
-        parameterizedTest(pow_Sets())
+        parameterizedTest(baseGreaterThanUnit_Sets())
         whenBaseNotZero
+        whenBaseNotUnit
         whenExponentNotZero
-        whenExponentNotOne
-        whenExponentLessThanOrEqualToMaxPermitted
+        whenExponentNotUnit
+    {
+        UD60x18 actual = pow(s.x, s.y);
+        assertEq(actual, s.expected);
+    }
+
+    function baseLessThanUnit_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: 1.78e18, expected: 0 }));
+        sets.push(set({ x: 0.01e18, y: E, expected: 0.000003659622955309e18 }));
+        sets.push(set({ x: 0.125e18, y: PI, expected: 0.001454987061394186e18 }));
+        sets.push(set({ x: 0.25e18, y: 3e18, expected: 0.015625e18 }));
+        sets.push(set({ x: 0.45e18, y: 2.2e18, expected: 0.172610627076774731e18 }));
+        sets.push(set({ x: 0.5e18, y: 0.481e18, expected: 0.716480825186549911e18 }));
+        sets.push(set({ x: 0.6e18, y: 0.95e18, expected: 0.615522152723696171e18 }));
+        sets.push(set({ x: 0.7e18, y: 3.1e18, expected: 0.330981655626097448e18 }));
+        sets.push(set({ x: 0.75e18, y: 4e18, expected: 0.316406250000000008e18 }));
+        sets.push(set({ x: 0.8e18, y: 5e18, expected: 0.327680000000000015e18 }));
+        sets.push(set({ x: 0.9e18, y: 2.5e18, expected: 0.768433471420916194e18 }));
+        sets.push(set({ x: 0.999999999999999999e18, y: 0.08e18, expected: UNIT }));
+        return sets;
+    }
+
+    function test_Pow_BaseLessThanUnit()
+        external
+        parameterizedTest(baseLessThanUnit_Sets())
+        whenBaseNotZero
+        whenBaseNotUnit
+        whenExponentNotZero
+        whenExponentNotUnit
     {
         UD60x18 actual = pow(s.x, s.y);
         assertEq(actual, s.expected);

--- a/test/ud60x18/math/pow/pow.tree
+++ b/test/ud60x18/math/pow/pow.tree
@@ -1,20 +1,23 @@
 pow.t.sol
 ├── when the base is zero
 │  ├── when the exponent is zero
-│  │  └── it should return one
+│  │  └── it should return the unit number
 │  └── when the exponent is not zero
 │     └── it should return zero
 └── when the base is not zero
-   ├── when the base is less than one
-   │  └── it should revert
-   └── when the base is greater than or equal to one
+   ├── when the base is the unit number
+   │  └── it should return the unit number
+   └── when the base is not the unit number
       ├── when the exponent is zero
-      │  └── it should return one
+      │  └── it should return the base
       └── when the exponent is not zero
-        ├── when the exponent is one
-        │  └── it should return the base
-        └── when the exponent is not one
-           ├── when the exponent is greater than the maximum permitted
-           │  └── it should revert
-           └── when the exponent is less than or equal to the maximum permitted
-              └── it should return the correct value
+         ├── when the exponent is the unit number
+         │  └── it should return the base
+         └── when the exponent is not the unit number
+            ├── when the base is greater than the maximum permitted
+            │  └── it should revert
+            └── when the base is less than or equal to the maximum permitted
+               ├── when the base is greater than the unit number
+               │  └── it should use the standard formula and return the correct value
+               └── when the base is less than the unit number
+                  └── it should use the equivalent formula and return the correct value


### PR DESCRIPTION
Updates `pow` so that it now works with values less than 1e18.

This PR closes https://github.com/PaulRBerg/prb-math/issues/181.