### PR TITLE
Fix truncated NatSpec for avg function

### DIFF
--- a/src/ud60x18/Math.sol
+++ b/src/ud60x18/Math.sol
@@ -28,7 +28,7 @@ import { UD60x18 } from "./ValueType.sol";
 /// $$
 /// avg(x, y) = (x & y) + ((xUint ^ yUint) / 2)
 /// $$
-//
+///
 /// In English, this is what this formula does:
 ///
 /// 1. AND x and y.


### PR DESCRIPTION
The NatSpec for the `avg` function is missing the `@notice` part because one of the lines is `//` instead of `///`.  This causes the function's documentation to only start from `In English, ...`

For example, the AST currently has the following:
```
        "documentation": {
          "id": 26595,
          "nodeType": "StructuredDocumentation",
          "src": "779:614:40",
          "text": "In English, ..."
        },
```