### PR TITLE
feat: add product ln function for UD60x18 type

### DIFF
--- a/src/Common.sol
+++ b/src/Common.sol
@@ -468,6 +468,25 @@ function mulDiv(uint256 x, uint256 y, uint256 denominator) pure returns (uint256
     }
 }
 
+/// @notice Calculates ceil(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+/// @param a The multiplicand
+/// @param b The multiplier
+/// @param denominator The divisor
+/// @return result The 256-bit result
+function mulDivUp(
+    uint256 a,
+    uint256 b,
+    uint256 denominator
+) pure returns (uint256 result) {
+    result = mulDiv(a, b, denominator);
+    unchecked {
+        if (mulmod(a, b, denominator) > 0) {
+            require(result < type(uint256).max);
+            result++;
+        }
+    }
+}
+
 /// @notice Calculates x*y÷1e18 with 512-bit precision.
 ///
 /// @dev A variant of {mulDiv} with constant folding, i.e. in which the denominator is hard coded to 1e18.

--- a/src/ud60x18/Errors.sol
+++ b/src/ud60x18/Errors.sol
@@ -38,3 +38,6 @@ error PRBMath_UD60x18_Log_InputTooSmall(UD60x18 x);
 
 /// @notice Thrown when calculating the square root overflows UD60x18.
 error PRBMath_UD60x18_Sqrt_Overflow(UD60x18 x);
+
+/// @notice Thrown when taking the product logarithm of a number greater than MAX_UD60x18 - UNIT.
+error PRBMath_UD60x18_ProductLn_InputTooBig(UD60x18 x);

--- a/src/ud60x18/Math.sol
+++ b/src/ud60x18/Math.sol
@@ -281,12 +281,13 @@ function productLn(UD60x18 x) pure returns (UD60x18 w) {
     }
 
     // Initial guess
-    w = ln(UNIT + x / (UNIT + HALF_UNIT * ln(UNIT + x)));
+    w = ln(UNIT + (x / (UNIT + HALF_UNIT * ln(UNIT + x))));
 
     // Iterative approximation
     // Four iterations gets us close to 18 decimals of precision
     for (uint256 i = 0; i < 4; i++) {
-        w = w / (w + UNIT) * (UNIT + ln(x / w));
+        if (w == ZERO) break; // Avoid division by zero and return.
+        w = (w  * (UNIT + ln(x / w))) / (w + UNIT);
     }
 }
 

--- a/src/ud60x18/Math.sol
+++ b/src/ud60x18/Math.sol
@@ -11,6 +11,7 @@ import {
     uLOG2_10,
     uLOG2_E,
     uMAX_UD60x18,
+    MAX_UD60x18,
     uMAX_WHOLE_UD60x18,
     UNIT,
     HALF_UNIT,
@@ -251,32 +252,39 @@ function ln(UD60x18 x) pure returns (UD60x18 result) {
     }
 }
 
-/// @notice Calculates the product logarithm of x, also known as the principal branch of the Lambert W function
-/// Where W(x) is the solution to x = W(x) * e^(W(x)).
+/// @notice Calculates the product logarithm of x, also known as the principal branch of the Lambert W function.
+/// The lambert-W function is defined as the inverse of the function f(x) = x * e^x, such that W(f(x)) = x.
 ///
 /// @dev this approximation uses an iterative approach defined for x > 0 in section 4.1 of the following paper:
-/// https://www.researchgate.net/publication/315904900_New_approximations_to_the_principal_real-valued_branch_of_the_Lambert_W-function
+/// https://www.researchgate.net/publication/315904900
 ///
 /// Notes:
 /// - This function depends on the {ln}, refer to notes there and in {log2}.
+/// - See https://mathworld.wolfram.com/LambertW-Function.html for information on the Lambert-W function.
 ///
 /// Requirements:
 /// - x must be greater than or equal to zero.
+/// - x must be less than `MAX_UD60x18 - UNIT`.
 ///
 /// @param x The UD60x18 number for which to calculate the product logarithm.
 /// @return w The product logarithm as a UD60x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function productLn(UD60x18 x) pure returns (UD60x18 w) {
     // If x is zero, the result is zero.
-    if (x.unwrap() == 0) {
+    if (x == ZERO) {
         return ZERO;
+    }
+
+    // The approximation requires that UNIT can be added to x without overflowing
+    if (x > MAX_UD60x18 - UNIT) {
+        revert Errors.PRBMath_UD60x18_ProductLn_InputTooBig(x);
     }
 
     // Initial guess
     w = ln(UNIT + x / (UNIT + HALF_UNIT * ln(UNIT + x)));
 
     // Iterative approximation
-    // Four iterations should get us to 18 decimals of precision
+    // Four iterations gets us close to 18 decimals of precision
     for (uint256 i = 0; i < 4; i++) {
         w = w / (w + UNIT) * (UNIT + ln(x / w));
     }

--- a/src/ud60x18/Math.sol
+++ b/src/ud60x18/Math.sol
@@ -287,7 +287,7 @@ function productLn(UD60x18 x) pure returns (UD60x18 w) {
     // Four iterations gets us close to 18 decimals of precision
     for (uint256 i = 0; i < 4; i++) {
         if (w == ZERO) break; // Avoid division by zero and return.
-        w = (w  * (UNIT + ln(x / w))) / (w + UNIT);
+        w = (w * (UNIT + ln(x / w))) / (w + UNIT);
     }
 }
 

--- a/src/ud60x18/ValueType.sol
+++ b/src/ud60x18/ValueType.sol
@@ -45,7 +45,8 @@ using {
     Math.mul,
     Math.pow,
     Math.powu,
-    Math.sqrt
+    Math.sqrt,
+    Math.productLn
 } for UD60x18 global;
 
 /*//////////////////////////////////////////////////////////////////////////

--- a/test/unit/ud60x18/math/productLn/productLn.t.sol
+++ b/test/unit/ud60x18/math/productLn/productLn.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "src/ud60x18/Constants.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT, EXP_MAX_INPUT } from "src/ud60x18/Constants.sol";
 import { PRBMath_UD60x18_ProductLn_InputTooBig } from "src/ud60x18/Errors.sol";
 import { productLn } from "src/ud60x18/Math.sol";
 import { UD60x18 } from "src/ud60x18/ValueType.sol";
@@ -17,6 +17,8 @@ contract ProductLn_Unit_Test is UD60x18_Unit_Test {
     }
 
     // Actual values as provided by Wolfram Alpha. Expected values differ slightly due to precision loss.
+    //     sets.push(set({ x: 0, expected: 0 }));
+    //     sets.push(set({ x: 10, expected: 10 }));
     //     sets.push(set({ x: 0.1e18, expected: 0.091276527160862264e18 }));
     //     sets.push(set({ x: 0.5e18, expected: 0.351733711249195826e18 }));
     //     sets.push(set({ x: 1e18, expected: 0.567143290409783872e18 }));
@@ -25,25 +27,50 @@ contract ProductLn_Unit_Test is UD60x18_Unit_Test {
     //     sets.push(set({ x: PI, expected: 1.073658194796149172e18 }));
     //     sets.push(set({ x: 4e18, expected: 1.202167873197042939e18 }));
     //     sets.push(set({ x: 8e18, expected: 1.605811996320177596e18 }));
+    //     sets.push(set({ x: 1 << 64, expected: 2.149604165721149567e18 }));
+    //     sets.push(set({ x: EXP_MAX_INPUT, expected: 3.607865991876595583e18 }));
+    //     sets.push(set({ x: 1 << 72, expected: 6.576554370186862927e18 }));
     //     sets.push(set({ x: 1e24, expected: 11.383358086140052622e18 }));
+    //     sets.push(set({ x: 1 << 80, expected: 11.557875688514566228e18 }));
+    //     sets.push(set({ x: 1 << 96, expected: 22.004357172804292983e18}));
+    //     sets.push(set({ x: 1 << 112, expected: 32.698619683327803298e18 }));
     //     sets.push(set({ x: 1e36, expected: 37.813856075588763228e18 }));
+    //     sets.push(set({ x: 1 << 128, expected: 43.503466806167642614e18 }));
+    //     sets.push(set({ x: 1 << 160, expected: 65.278356678784907906e18 }));
+    //     sets.push(set({ x: 1 << 192, expected: 87.169868269781877264e18 }));
+    //     sets.push(set({ x: 1 << 224, expected: 109.125934196618053331e18 }));
+    //     sets.push(set({ x: 1 << 232, expected: 114.621974678990178815e18 }));
+    //     sets.push(set({ x: 1 << 240, expected: 120.120297937053547320e18 }));
     //     sets.push(set({ x: MAX_WHOLE_UD60x18, expected: 131.123010654220946391e18 }));
     //     sets.push(set({ x: MAX_UD60x18, expected: 131.123010654220946391e18 }));
     function productLn_Sets() internal returns (Set[] memory) {
         delete sets;
         sets.push(set({ x: 0, expected: 0 }));
+        sets.push(set({ x: 10, expected: 8 })); // 2 wei off
         sets.push(set({ x: 0.1e18, expected: 0.091276527160862263e18 })); // 1 wei off
         sets.push(set({ x: 0.5e18, expected: 0.351733711249195823e18 })); // 3 wei off
         sets.push(set({ x: 1e18, expected: 0.567143290409783868e18 })); // 4 wei off
-        sets.push(set({ x: 2e18, expected: 0.852605502013725487e18 })); // 4 wei off
+        sets.push(set({ x: 2e18, expected: 0.852605502013725488e18 })); // 3 wei off
         sets.push(set({ x: E, expected: 0.999999999999999994e18 })); // 6 wei off
         sets.push(set({ x: PI, expected: 1.073658194796149166e18 })); // 6 wei off
         sets.push(set({ x: 4e18, expected: 1.202167873197042932e18 })); // 7 wei off
-        sets.push(set({ x: 8e18, expected: 1.605811996320177591e18 })); // 5 wei off
-        sets.push(set({ x: 1e24, expected: 11.383358086140052608e18 })); // 14 wei off
-        sets.push(set({ x: 1e36, expected: 37.813856075588763202e18 })); // 26 wei off
-        sets.push(set({ x: MAX_WHOLE_UD60x18 - UNIT, expected: 131.123010654220946305e18 })); // 86 wei off
-        sets.push(set({ x: MAX_UD60x18 - UNIT, expected: 131.123010654220946305e18 })); // 86 wei off
+        sets.push(set({ x: 8e18, expected: 1.60581199632017759e18 })); // 6 wei off
+        sets.push(set({ x: 1 << 64, expected: 2.14960416572114956e18 })); // 7 wei off
+        sets.push(set({ x: EXP_MAX_INPUT, expected: 3.607865991876595576e18 })); // 7 wei off
+        sets.push(set({ x: 1 << 72, expected: 6.576554370186862919e18 })); // 8 wei off
+        sets.push(set({ x: 1e24, expected: 11.383358086140052615e18 })); // 7 wei off
+        sets.push(set({ x: 1 << 80, expected: 11.55787568851456622e18 })); // 8 wei off
+        sets.push(set({ x: 1 << 96, expected: 22.00435717280429298e18 })); // 3 wei off
+        sets.push(set({ x: 1 << 112, expected: 32.698619683327803296e18 })); // 2 wei off
+        sets.push(set({ x: 1e36, expected: 37.813856075588763228e18 })); // 0 wei off
+        sets.push(set({ x: 1 << 128, expected: 43.503466806167642615e18 })); // -1 wei off
+        sets.push(set({ x: 1 << 160, expected: 65.278356678784907912e18 })); // -6 wei off
+        sets.push(set({ x: 1 << 192, expected: 87.169868269781877274e18 })); // -10 wei off
+        sets.push(set({ x: 1 << 224, expected: 109.125934196618053348e18 })); // -17 wei off
+        sets.push(set({ x: 1 << 232, expected: 114.621974678990178834e18 })); // -19 wei off
+        sets.push(set({ x: 1 << 240, expected: 120.120297937053547337e18 })); // -17 wei off
+        sets.push(set({ x: MAX_WHOLE_UD60x18 - UNIT, expected: 131.123010654220946415e18 })); // -24 wei off
+        sets.push(set({ x: MAX_UD60x18 - UNIT, expected: 131.123010654220946415e18 })); // -24 wei off
         return sets;
     }
 
@@ -57,5 +84,26 @@ contract ProductLn_Unit_Test is UD60x18_Unit_Test {
         uint256 preGas = gasleft();
         productLn(x);
         console2.log("Gas used: productLn ", preGas - gasleft());
+    }
+
+    // We limit fuzz values to 2^72 - 1 since the max exponential input is less than this anyways.
+    function testFuzz_ProductLn_ErrorBound(uint72 x_) external pure {
+        UD60x18 x = UD60x18.wrap(uint256(x_));
+        x = x % (EXP_MAX_INPUT + UD60x18.wrap(1)); // limit the input to the max exponential input for comparison
+        if (x > MAX_UD60x18 / x.exp()) return; // product of x and e^x must be less than the max UD60x18 value
+
+        // Using the identity: x = W(x * e^x), we can check the internal error bound below for the exp and productLn function
+        // roundtrip below the selected input.
+        // The error bound is calculated as the absolute difference between the actual value and the expected value,
+        // knowing our approximation is less than the actual value for this value range.
+        UD60x18 w = x.exp().mul(x);
+        console2.log("xex: ", w.unwrap());
+        w = productLn(w);
+
+        UD60x18 err = x - w;
+        console2.log("x: ", x.unwrap());
+        console2.log("w: ", w.unwrap());
+        console2.log("err: ", err.unwrap());
+        assertLe(err.unwrap(), 17); // Determined by iterative fuzzing with the maximum possible number of fuzz runs (2^32 - 1)
     }
 }

--- a/test/unit/ud60x18/math/productLn/productLn.t.sol
+++ b/test/unit/ud60x18/math/productLn/productLn.t.sol
@@ -52,7 +52,7 @@ contract ProductLn_Unit_Test is UD60x18_Unit_Test {
         assertEq(actual, s.expected, "UD60x18 productLn");
     }
 
-    function test_ProductLn_Gas() external {
+    function test_ProductLn_Gas() external view {
         UD60x18 x = UD60x18.wrap(1e18);
         uint256 preGas = gasleft();
         productLn(x);

--- a/test/unit/ud60x18/math/productLn/productLn.t.sol
+++ b/test/unit/ud60x18/math/productLn/productLn.t.sol
@@ -7,8 +7,9 @@ import { productLn } from "src/ud60x18/Math.sol";
 import { UD60x18 } from "src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+import { console2 } from "node_modules/forge-std/src/console2.sol";
 
-contract Product_Ln_Unit_Test is UD60x18_Unit_Test {
+contract ProductLn_Unit_Test is UD60x18_Unit_Test {
     function test_RevertWhen_GtMaxMinusUnit() external {
         UD60x18 x = MAX_UD60x18 - UNIT + UD60x18.wrap(1);
         vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_ProductLn_InputTooBig.selector, x));
@@ -49,5 +50,12 @@ contract Product_Ln_Unit_Test is UD60x18_Unit_Test {
     function test_ProductLn() external parameterizedTest(productLn_Sets()) {
         UD60x18 actual = productLn(s.x);
         assertEq(actual, s.expected, "UD60x18 productLn");
+    }
+
+    function test_ProductLn_Gas() external {
+        UD60x18 x = UD60x18.wrap(1e18);
+        uint256 preGas = gasleft();
+        productLn(x);
+        console2.log("Gas used: productLn ", preGas - gasleft());
     }
 }

--- a/test/unit/ud60x18/math/productLn/productLn.t.sol
+++ b/test/unit/ud60x18/math/productLn/productLn.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_ProductLn_InputTooBig } from "src/ud60x18/Errors.sol";
+import { productLn } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Product_Ln_Unit_Test is UD60x18_Unit_Test {
+    function test_RevertWhen_GtMaxMinusUnit() external {
+        UD60x18 x = MAX_UD60x18 - UNIT + UD60x18.wrap(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_ProductLn_InputTooBig.selector, x));
+        productLn(x);
+    }
+
+    // Actual values as provided by Wolfram Alpha. Expected values differ slightly due to precision loss.
+    //     sets.push(set({ x: 0.1e18, expected: 0.091276527160862264e18 }));
+    //     sets.push(set({ x: 0.5e18, expected: 0.351733711249195826e18 }));
+    //     sets.push(set({ x: 1e18, expected: 0.567143290409783872e18 }));
+    //     sets.push(set({ x: 2e18, expected: 0.852605502013725491e18 }));
+    //     sets.push(set({ x: E, expected: 0.99999999999999999e18 }));
+    //     sets.push(set({ x: PI, expected: 1.073658194796149172e18 }));
+    //     sets.push(set({ x: 4e18, expected: 1.202167873197042939e18 }));
+    //     sets.push(set({ x: 8e18, expected: 1.605811996320177596e18 }));
+    //     sets.push(set({ x: 1e24, expected: 11.383358086140052622e18 }));
+    //     sets.push(set({ x: 1e36, expected: 37.813856075588763228e18 }));
+    //     sets.push(set({ x: MAX_WHOLE_UD60x18, expected: 131.123010654220946391e18 }));
+    //     sets.push(set({ x: MAX_UD60x18, expected: 131.123010654220946391e18 }));
+    function productLn_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, expected: 0 }));
+        sets.push(set({ x: 0.1e18, expected: 0.091276527160862263e18 })); // 1 wei off
+        sets.push(set({ x: 0.5e18, expected: 0.351733711249195823e18 })); // 3 wei off
+        sets.push(set({ x: 1e18, expected: 0.567143290409783868e18 })); // 4 wei off
+        sets.push(set({ x: 2e18, expected: 0.852605502013725487e18 })); // 4 wei off
+        sets.push(set({ x: E, expected: 0.999999999999999994e18 })); // 6 wei off
+        sets.push(set({ x: PI, expected: 1.073658194796149166e18 })); // 6 wei off
+        sets.push(set({ x: 4e18, expected: 1.202167873197042932e18 })); // 7 wei off
+        sets.push(set({ x: 8e18, expected: 1.605811996320177591e18 })); // 5 wei off
+        sets.push(set({ x: 1e24, expected: 11.383358086140052608e18 })); // 14 wei off
+        sets.push(set({ x: 1e36, expected: 37.813856075588763202e18 })); // 26 wei off
+        sets.push(set({ x: MAX_WHOLE_UD60x18 - UNIT, expected: 131.123010654220946305e18 })); // 86 wei off
+        sets.push(set({ x: MAX_UD60x18 - UNIT, expected: 131.123010654220946305e18 })); // 86 wei off
+        return sets;
+    }
+
+    function test_ProductLn() external parameterizedTest(productLn_Sets()) {
+        UD60x18 actual = productLn(s.x);
+        assertEq(actual, s.expected, "UD60x18 productLn");
+    }
+}

--- a/test/unit/ud60x18/math/productLn/productLn.tree
+++ b/test/unit/ud60x18/math/productLn/productLn.tree
@@ -1,0 +1,7 @@
+productLn.t.sol
+├── when x is zero
+│  └── it should return zero
+├── when x is greater than MaxUD60x18 - UNIT
+│  └── it should revert
+└── when x is greater than zero and less than or equal to MaxUD60x18 - UNIT
+   └── it should return the correct value


### PR DESCRIPTION
Unsolicited PR to add an approximation for the [Lambert W-function](https://mathworld.wolfram.com/LambertW-Function.html) , also known as "ProductLog" in WolframAlpha, to the UD60x18 type. The Lambert W-function is the inverse function of the transcendental equation $f(x) = x * e^x$ such that $W(f(x)) = x$. It appears in various solutions to exponential equations, such described [here](https://en.wikipedia.org/wiki/Lambert_W_function#Applications).

Motivation: The Lambert W-function is needed in the `payoutFor` calculation in a Gradual Dutch Auction with a minimum price, as described in this [post](https://oighty.eth.limo/gda-w-min-price/). Rather than add this in my project repo, I thought it may be helpful to others if contributed back to this library.

Implementation: The Lambert W-function, implemented as `productLn`, is a complex function with multiple branches and is not trivial to calculate. However, since it appears in various physics domains, much work has been done developing approximations for its different branches. In the case of an unsigned integer, we only care about the "principal" real branch from $x \in [0, \infty)$. This [paper](https://www.researchgate.net/publication/315904900_New_approximations_to_the_principal_real-valued_branch_of_the_Lambert_W-function) provides an overview of previous approximation methodologies and proposes a simple iterative method for approximating our target branch for $x > 0$. The iteration leverages the natural logarithm, and so we rely on the existing `ln` implementation in the library. An error analysis of the method in the paper shows that it achieves "machine precision", seemingly defined as with $10^{-16}$, with three iterations. I've implemented it here with four to try and get the extra couple decimal places, but it can potentially be dropped to three to save gas. Four iterations requires six `ln` calls, which is the major factor in the gas cost of the function.

Appreciate any feedback. I modeled the tests based on what was already written for the `ln` function, but happy to add additional tests or make stylistic changes if needed.
