### PR TITLE
Threshold check

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,7 @@
   test = "test"
 
 [profile.ci]
-  fuzz = { runs = 10_000 }
+  fuzz = { runs = 10_000, max_test_rejects = 100_000 }
   verbosity = 4
 
 [fmt]

--- a/src/sd59x18/Constants.sol
+++ b/src/sd59x18/Constants.sol
@@ -12,6 +12,10 @@ SD59x18 constant E = SD59x18.wrap(2_718281828459045235);
 int256 constant uEXP_MAX_INPUT = 133_084258667509499440;
 SD59x18 constant EXP_MAX_INPUT = SD59x18.wrap(uEXP_MAX_INPUT);
 
+/// @dev Any value less than this returns 0 in {exp}.
+int256 constant uEXP_MIN_THRESHOLD = -41_446531673892822322;
+SD59x18 constant EXP_MIN_THRESHOLD = SD59x18.wrap(uEXP_MIN_THRESHOLD);
+
 /// @dev The maximum input permitted in {exp2}.
 int256 constant uEXP2_MAX_INPUT = 192e18 - 1;
 SD59x18 constant EXP2_MAX_INPUT = SD59x18.wrap(uEXP2_MAX_INPUT);

--- a/src/sd59x18/Constants.sol
+++ b/src/sd59x18/Constants.sol
@@ -16,6 +16,10 @@ SD59x18 constant EXP_MAX_INPUT = SD59x18.wrap(uEXP_MAX_INPUT);
 int256 constant uEXP2_MAX_INPUT = 192e18 - 1;
 SD59x18 constant EXP2_MAX_INPUT = SD59x18.wrap(uEXP2_MAX_INPUT);
 
+/// @dev Any value less than this will return 0 in {exp2}.
+int256 constant uEXP2_MIN_THRESHOLD = -59_794705707972522261;
+SD59x18 constant EXP2_MIN_THRESHOLD = SD59x18.wrap(uEXP2_MIN_THRESHOLD);
+
 /// @dev Half the UNIT number.
 int256 constant uHALF_UNIT = 0.5e18;
 SD59x18 constant HALF_UNIT = SD59x18.wrap(uHALF_UNIT);

--- a/src/sd59x18/Constants.sol
+++ b/src/sd59x18/Constants.sol
@@ -16,7 +16,7 @@ SD59x18 constant EXP_MAX_INPUT = SD59x18.wrap(uEXP_MAX_INPUT);
 int256 constant uEXP2_MAX_INPUT = 192e18 - 1;
 SD59x18 constant EXP2_MAX_INPUT = SD59x18.wrap(uEXP2_MAX_INPUT);
 
-/// @dev Any value less than this will return 0 in {exp2}.
+/// @dev Any value less than this returns 0 in {exp2}.
 int256 constant uEXP2_MIN_THRESHOLD = -59_794705707972522261;
 SD59x18 constant EXP2_MIN_THRESHOLD = SD59x18.wrap(uEXP2_MIN_THRESHOLD);
 

--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -169,12 +169,14 @@ function div(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
 function exp(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
 
+    // TODO: add explanatory comment.
+    if (xInt < uEXP2_MIN_THRESHOLD) {
+        return ZERO;
+    }
+
     // This check prevents values greater than 192e18 from being passed to {exp2}.
     if (xInt > uEXP_MAX_INPUT) {
         revert Errors.PRBMath_SD59x18_Exp_InputTooBig(x);
-    }
-    if (xInt < uEXP2_MIN_THRESHOLD) {
-        return ZERO;
     }
 
     unchecked {
@@ -205,7 +207,7 @@ function exp(SD59x18 x) pure returns (SD59x18 result) {
 function exp2(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
     if (xInt < 0) {
-        // The inverse of any number less than this is truncated to zero.
+        // The inverse of any number less than the threshold is truncated to zero.
         if (xInt < uEXP2_MIN_THRESHOLD) {
             return ZERO;
         }

--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -6,6 +6,7 @@ import "./Errors.sol" as Errors;
 import {
     uEXP_MAX_INPUT,
     uEXP2_MAX_INPUT,
+    uEXP2_MIN_THRESHOLD,
     uHALF_UNIT,
     uLOG2_10,
     uLOG2_E,
@@ -172,6 +173,9 @@ function exp(SD59x18 x) pure returns (SD59x18 result) {
     if (xInt > uEXP_MAX_INPUT) {
         revert Errors.PRBMath_SD59x18_Exp_InputTooBig(x);
     }
+    if (xInt < uEXP2_MIN_THRESHOLD) {
+        return ZERO;
+    }
 
     unchecked {
         // Inline the fixed-point multiplication to save gas.
@@ -202,7 +206,7 @@ function exp2(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
     if (xInt < 0) {
         // The inverse of any number less than this is truncated to zero.
-        if (xInt < -59_794705707972522261) {
+        if (xInt < uEXP2_MIN_THRESHOLD) {
             return ZERO;
         }
 

--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -170,8 +170,8 @@ function div(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
 function exp(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
 
-    // Any input less than the threshold will result in exp returning 0
-    // This also prevents an overflow later in the function for very small numbers
+    // Any input less than the threshold returns zero.
+    // This check also prevents an overflow for very small numbers.
     if (xInt < uEXP_MIN_THRESHOLD) {
         return ZERO;
     }

--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -6,6 +6,7 @@ import "./Errors.sol" as Errors;
 import {
     uEXP_MAX_INPUT,
     uEXP2_MAX_INPUT,
+    uEXP_MIN_THRESHOLD,
     uEXP2_MIN_THRESHOLD,
     uHALF_UNIT,
     uLOG2_10,
@@ -169,8 +170,9 @@ function div(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
 function exp(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
 
-    // TODO: add explanatory comment.
-    if (xInt < uEXP2_MIN_THRESHOLD) {
+    // Any input less than the threshold will result in exp returning 0
+    // This also prevents an overflow later in the function for very small numbers
+    if (xInt < uEXP_MIN_THRESHOLD) {
         return ZERO;
     }
 

--- a/test/unit/sd59x18/math/exp/exp.t.sol
+++ b/test/unit/sd59x18/math/exp/exp.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { sd } from "src/sd59x18/Casting.sol";
-import { E, EXP_MAX_INPUT, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
+import { E, EXP_MAX_INPUT, EXP_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
 import { PRBMath_SD59x18_Exp_InputTooBig } from "src/sd59x18/Errors.sol";
 import { exp } from "src/sd59x18/Math.sol";
 import { SD59x18 } from "src/sd59x18/ValueType.sol";
@@ -10,8 +10,6 @@ import { SD59x18 } from "src/sd59x18/ValueType.sol";
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 
 contract Exp_Unit_Test is SD59x18_Unit_Test {
-    SD59x18 internal constant THRESHOLD = SD59x18.wrap(-41_446531673892822322);
-
     function test_Exp_Zero() external pure {
         SD59x18 x = ZERO;
         SD59x18 actual = exp(x);
@@ -27,7 +25,7 @@ contract Exp_Unit_Test is SD59x18_Unit_Test {
         delete sets;
         sets.push(set({ x: MIN_SD59x18 }));
         sets.push(set({ x: MIN_WHOLE_SD59x18 }));
-        sets.push(set({ x: THRESHOLD - sd(1) }));
+        sets.push(set({ x: EXP_MIN_THRESHOLD - sd(1) }));
         return sets;
     }
 
@@ -38,7 +36,9 @@ contract Exp_Unit_Test is SD59x18_Unit_Test {
 
     function negativeAndGteThreshold_Sets() internal returns (Set[] memory) {
         delete sets;
-        sets.push(set({ x: THRESHOLD, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: MIN_SD59x18, expected: 0 }));
+        sets.push(set({ x: EXP_MIN_THRESHOLD - sd(1), expected: 0 }));
+        sets.push(set({ x: EXP_MIN_THRESHOLD, expected: 0.000000000000000001e18 }));
         sets.push(set({ x: -33.333333e18, expected: 0.000000000000003338e18 }));
         sets.push(set({ x: -20.82e18, expected: 0.0000000009077973e18 }));
         sets.push(set({ x: -16e18, expected: 0.000000112535174719e18 }));

--- a/test/unit/sd59x18/math/exp2/exp2.t.sol
+++ b/test/unit/sd59x18/math/exp2/exp2.t.sol
@@ -2,17 +2,7 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { sd } from "src/sd59x18/Casting.sol";
-import {
-    E,
-    EXP2_MAX_INPUT,
-    EXP2_MIN_THRESHOLD,
-    MIN_SD59x18,
-    MIN_WHOLE_SD59x18,
-    PI,
-    UNIT,
-    uEXP2_MIN_THRESHOLD,
-    ZERO
-} from "src/sd59x18/Constants.sol";
+import { E, EXP2_MAX_INPUT, EXP2_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
 import { PRBMath_SD59x18_Exp2_InputTooBig } from "src/sd59x18/Errors.sol";
 import { exp2 } from "src/sd59x18/Math.sol";
 import { SD59x18 } from "src/sd59x18/ValueType.sol";
@@ -47,8 +37,8 @@ contract Exp2_Unit_Test is SD59x18_Unit_Test {
     function negativeAndGteMinPermitted_Sets() internal returns (Set[] memory) {
         delete sets;
         sets.push(set({ x: MIN_SD59x18, expected: 0 }));
-        sets.push(set({ x: EXP2_MIN_THRESHOLD, expected: 0.000000000000000001e18 }));
         sets.push(set({ x: EXP2_MIN_THRESHOLD - sd(1), expected: 0 }));
+        sets.push(set({ x: EXP2_MIN_THRESHOLD, expected: 0.000000000000000001e18 }));
         sets.push(set({ x: -33.333333e18, expected: 0.000000000092398923e18 }));
         sets.push(set({ x: -20.82e18, expected: 0.000000540201132438e18 }));
         sets.push(set({ x: -16e18, expected: 0.0000152587890625e18 }));

--- a/test/unit/sd59x18/math/exp2/exp2.t.sol
+++ b/test/unit/sd59x18/math/exp2/exp2.t.sol
@@ -2,7 +2,17 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { sd } from "src/sd59x18/Casting.sol";
-import { E, EXP2_MAX_INPUT, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO, uEXP2_MIN_THRESHOLD, EXP2_MIN_THRESHOLD } from "src/sd59x18/Constants.sol";
+import {
+    E,
+    EXP2_MAX_INPUT,
+    EXP2_MIN_THRESHOLD,
+    MIN_SD59x18,
+    MIN_WHOLE_SD59x18,
+    PI,
+    UNIT,
+    uEXP2_MIN_THRESHOLD,
+    ZERO
+} from "src/sd59x18/Constants.sol";
 import { PRBMath_SD59x18_Exp2_InputTooBig } from "src/sd59x18/Errors.sol";
 import { exp2 } from "src/sd59x18/Math.sol";
 import { SD59x18 } from "src/sd59x18/ValueType.sol";
@@ -10,7 +20,6 @@ import { SD59x18 } from "src/sd59x18/ValueType.sol";
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 
 contract Exp2_Unit_Test is SD59x18_Unit_Test {
-
     function test_Exp2_Zero() external pure {
         SD59x18 x = ZERO;
         SD59x18 actual = exp2(x);
@@ -37,9 +46,9 @@ contract Exp2_Unit_Test is SD59x18_Unit_Test {
 
     function negativeAndGteMinPermitted_Sets() internal returns (Set[] memory) {
         delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: 0 }));
         sets.push(set({ x: EXP2_MIN_THRESHOLD, expected: 0.000000000000000001e18 }));
         sets.push(set({ x: EXP2_MIN_THRESHOLD - sd(1), expected: 0 }));
-        sets.push(set({ x: -sd(2**255-1), expected: 0 }));
         sets.push(set({ x: -33.333333e18, expected: 0.000000000092398923e18 }));
         sets.push(set({ x: -20.82e18, expected: 0.000000540201132438e18 }));
         sets.push(set({ x: -16e18, expected: 0.0000152587890625e18 }));

--- a/test/unit/sd59x18/math/exp2/exp2.t.sol
+++ b/test/unit/sd59x18/math/exp2/exp2.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.19 <0.9.0;
 
 import { sd } from "src/sd59x18/Casting.sol";
-import { E, EXP2_MAX_INPUT, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
+import { E, EXP2_MAX_INPUT, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO, uEXP2_MIN_THRESHOLD, EXP2_MIN_THRESHOLD } from "src/sd59x18/Constants.sol";
 import { PRBMath_SD59x18_Exp2_InputTooBig } from "src/sd59x18/Errors.sol";
 import { exp2 } from "src/sd59x18/Math.sol";
 import { SD59x18 } from "src/sd59x18/ValueType.sol";
@@ -10,8 +10,6 @@ import { SD59x18 } from "src/sd59x18/ValueType.sol";
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 
 contract Exp2_Unit_Test is SD59x18_Unit_Test {
-    /// @dev Any input smaller than this makes the result zero.
-    SD59x18 internal constant THRESHOLD = SD59x18.wrap(-59_794705707972522261);
 
     function test_Exp2_Zero() external pure {
         SD59x18 x = ZERO;
@@ -28,7 +26,7 @@ contract Exp2_Unit_Test is SD59x18_Unit_Test {
         delete sets;
         sets.push(set({ x: MIN_SD59x18, expected: 0 }));
         sets.push(set({ x: MIN_WHOLE_SD59x18, expected: 0 }));
-        sets.push(set({ x: THRESHOLD - sd(1), expected: 0 }));
+        sets.push(set({ x: EXP2_MIN_THRESHOLD - sd(1), expected: 0 }));
         return sets;
     }
 
@@ -39,7 +37,9 @@ contract Exp2_Unit_Test is SD59x18_Unit_Test {
 
     function negativeAndGteMinPermitted_Sets() internal returns (Set[] memory) {
         delete sets;
-        sets.push(set({ x: THRESHOLD, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: EXP2_MIN_THRESHOLD, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: EXP2_MIN_THRESHOLD - sd(1), expected: 0 }));
+        sets.push(set({ x: -sd(2**255-1), expected: 0 }));
         sets.push(set({ x: -33.333333e18, expected: 0.000000000092398923e18 }));
         sets.push(set({ x: -20.82e18, expected: 0.000000540201132438e18 }));
         sets.push(set({ x: -16e18, expected: 0.0000152587890625e18 }));


### PR DESCRIPTION
I've implemented the changes requested in this PR. However, I'm encountering a failure during the build due to fuzz tests on unchanged code. The issue is only occurring within the GitHub Actions workflow but test runs fine locally. So possibly due to foundry versions.

Error Details:

Reason: The `vm.assume` cheatcode rejected too many inputs (65536 allowed)] testFuzz_Rshift(uint256, uint256) (runs: 7354, μ: 4038, ~: 4038)

It seems that the fuzz test is reaching the maximum input rejection threshold.

To get the tests to pass I increased max_test_rejects to 100_000 [Foundry documentation](https://book.getfoundry.sh/reference/config/testing#max_test_rejects). The default is 65_536

Do you have any other suggestions?


