### PR TITLE
Use return instead of param for return parameter documentation

### DIFF
--- a/src/sd59x18/Conversions.sol
+++ b/src/sd59x18/Conversions.sol
@@ -12,7 +12,7 @@ import { SD59x18 } from "./ValueType.sol";
 /// - x ≤ `MAX_SD59x18 / UNIT`
 ///
 /// @param x The basic integer to convert.
-/// @param result The same number converted to SD59x18.
+/// @return result The same number converted to SD59x18.
 function convert(int256 x) pure returns (SD59x18 result) {
     if (x < uMIN_SD59x18 / uUNIT) {
         revert PRBMath_SD59x18_Convert_Underflow(x);

--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -29,7 +29,7 @@ import { SD59x18 } from "./ValueType.sol";
 /// - x > MIN_SD59x18.
 ///
 /// @param x The SD59x18 number for which to calculate the absolute value.
-/// @param result The absolute value of x as an SD59x18 number.
+/// @return result The absolute value of x as an SD59x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function abs(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
@@ -78,7 +78,7 @@ function avg(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
 /// - x ≤ MAX_WHOLE_SD59x18
 ///
 /// @param x The SD59x18 number to ceil.
-/// @param result The smallest whole number greater than or equal to x, as an SD59x18 number.
+/// @return result The smallest whole number greater than or equal to x, as an SD59x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function ceil(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
@@ -118,7 +118,7 @@ function ceil(SD59x18 x) pure returns (SD59x18 result) {
 ///
 /// @param x The numerator as an SD59x18 number.
 /// @param y The denominator as an SD59x18 number.
-/// @param result The quotient as an SD59x18 number.
+/// @return result The quotient as an SD59x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function div(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
@@ -243,7 +243,7 @@ function exp2(SD59x18 x) pure returns (SD59x18 result) {
 /// - x ≥ MIN_WHOLE_SD59x18
 ///
 /// @param x The SD59x18 number to floor.
-/// @param result The greatest whole number less than or equal to x, as an SD59x18 number.
+/// @return result The greatest whole number less than or equal to x, as an SD59x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function floor(SD59x18 x) pure returns (SD59x18 result) {
     int256 xInt = x.unwrap();
@@ -270,7 +270,7 @@ function floor(SD59x18 x) pure returns (SD59x18 result) {
 /// of the radix point for negative numbers.
 /// @dev Based on the odd function definition. https://en.wikipedia.org/wiki/Fractional_part
 /// @param x The SD59x18 number to get the fractional part of.
-/// @param result The fractional part of x as an SD59x18 number.
+/// @return result The fractional part of x as an SD59x18 number.
 function frac(SD59x18 x) pure returns (SD59x18 result) {
     result = wrap(x.unwrap() % uUNIT);
 }

--- a/src/ud60x18/Conversions.sol
+++ b/src/ud60x18/Conversions.sol
@@ -19,7 +19,7 @@ function convert(UD60x18 x) pure returns (uint256 result) {
 /// - x ≤ MAX_UD60x18 / UNIT
 ///
 /// @param x The basic integer to convert.
-/// @param result The same number converted to UD60x18.
+/// @return result The same number converted to UD60x18.
 function convert(uint256 x) pure returns (UD60x18 result) {
     if (x > uMAX_UD60x18 / uUNIT) {
         revert PRBMath_UD60x18_Convert_Overflow(x);

--- a/src/ud60x18/Math.sol
+++ b/src/ud60x18/Math.sol
@@ -62,7 +62,7 @@ function avg(UD60x18 x, UD60x18 y) pure returns (UD60x18 result) {
 /// - x ≤ MAX_WHOLE_UD60x18
 ///
 /// @param x The UD60x18 number to ceil.
-/// @param result The smallest whole number greater than or equal to x, as a UD60x18 number.
+/// @return result The smallest whole number greater than or equal to x, as a UD60x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function ceil(UD60x18 x) pure returns (UD60x18 result) {
     uint256 xUint = x.unwrap();
@@ -94,7 +94,7 @@ function ceil(UD60x18 x) pure returns (UD60x18 result) {
 ///
 /// @param x The numerator as a UD60x18 number.
 /// @param y The denominator as a UD60x18 number.
-/// @param result The quotient as a UD60x18 number.
+/// @return result The quotient as a UD60x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function div(UD60x18 x, UD60x18 y) pure returns (UD60x18 result) {
     result = wrap(Common.mulDiv(x.unwrap(), uUNIT, y.unwrap()));
@@ -157,7 +157,7 @@ function exp2(UD60x18 x) pure returns (UD60x18 result) {
 /// @dev Optimized for fractional value inputs, because every whole value has (1e18 - 1) fractional counterparts.
 /// See https://en.wikipedia.org/wiki/Floor_and_ceiling_functions.
 /// @param x The UD60x18 number to floor.
-/// @param result The greatest whole number less than or equal to x, as a UD60x18 number.
+/// @return result The greatest whole number less than or equal to x, as a UD60x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function floor(UD60x18 x) pure returns (UD60x18 result) {
     assembly ("memory-safe") {
@@ -172,7 +172,7 @@ function floor(UD60x18 x) pure returns (UD60x18 result) {
 /// @notice Yields the excess beyond the floor of x using the odd function definition.
 /// @dev See https://en.wikipedia.org/wiki/Fractional_part.
 /// @param x The UD60x18 number to get the fractional part of.
-/// @param result The fractional part of x as a UD60x18 number.
+/// @return result The fractional part of x as a UD60x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function frac(UD60x18 x) pure returns (UD60x18 result) {
     assembly ("memory-safe") {


### PR DESCRIPTION
Some functions document the return parameter using the `@param` NatSpec tag, and the Solidity compiler does not fail in these cases.  However, since these are referring to return parameters instead of function parameters, it would be more correct to document them as `@return` instead.