### PR TITLE
test: remove duplicated test

### DIFF
--- a/test/unit/ud60x18/math/pow/pow.t.sol
+++ b/test/unit/ud60x18/math/pow/pow.t.sol
@@ -52,14 +52,6 @@ contract Pow_Unit_Test is UD60x18_Unit_Test {
         _;
     }
 
-    function test_Pow_ExponentUnit(UD60x18 x) external pure whenBaseNotZero whenBaseNotUnit whenExponentNotZero {
-        vm.assume(x != ZERO && x != UNIT);
-        UD60x18 y = UNIT;
-        UD60x18 actual = pow(x, y);
-        UD60x18 expected = x;
-        assertEq(actual, expected, "UD60x18 pow");
-    }
-
     modifier whenExponentNotUnit() {
         _;
     }

--- a/test/unit/ud60x18/math/pow/pow.t.sol
+++ b/test/unit/ud60x18/math/pow/pow.t.sol
@@ -52,6 +52,14 @@ contract Pow_Unit_Test is UD60x18_Unit_Test {
         _;
     }
 
+    function test_Pow_ExponentUnit() external pure whenBaseNotZero whenBaseNotUnit whenExponentNotZero {
+        UD60x18 x = PI;
+        UD60x18 y = UNIT;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = x;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
     modifier whenExponentNotUnit() {
         _;
     }


### PR DESCRIPTION
I was using this repo to test [a new feature](https://github.com/fvictorio/slippy/pull/16) of Slippy, and the only erorr I got was this function, which should be called `testFuzz_...`. But then I noticed that fuzz tests were in their own directory, so I thought of moving it... and then I noticed that it was already there:

https://github.com/PaulRBerg/prb-math/blob/daedfb0d72c5501aea62b28a10d57c46f6983a60/test/fuzz/ud60x18/math/pow/pow.t.sol#L46-L52