### PR TITLE
test: add fuzz tests for msb and sqrt

### DIFF
--- a/test/.solhint.json
+++ b/test/.solhint.json
@@ -2,6 +2,7 @@
   "rules": {
     "const-name-snakecase": "off",
     "contract-name-capwords": "off",
+    "gas-small-strings": "off",
     "func-name-mixedcase": "off",
     "no-console": "off"
   }

--- a/test/fuzz/common/msb.t.sol
+++ b/test/fuzz/common/msb.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19 <0.9.0;
+
+import { msb } from "src/Common.sol";
+
+import { Base_Test } from "../../Base.t.sol";
+
+/// @dev Collection of tests for the most significant bit function available in `Common.sol`.
+contract Common_Sqrt_Test is Base_Test {
+    function testFuzz_Msb_FitsUint8(uint256 x) external pure {
+        assertLe(msb(x), type(uint8).max, "Common msb");
+    }
+
+    modifier whenNotZero(uint256 x) {
+        vm.assume(x != 0);
+        _;
+    }
+
+    function testFuzz_Msb_ShiftsXToOneBit(uint256 x) external pure whenNotZero(x) {
+        assertEq(x >> msb(x), 1, "Common msb");
+    }
+
+    function testFuzz_Msb_Shifts1ToLessThanOrEqualToX(uint256 x) external pure whenNotZero(x) {
+        assertLe(1 << msb(x), x, "Common msb");
+    }
+
+    modifier whenShiftLeftDoesNotOverflow(uint256 x) {
+        vm.assume(x <= type(uint256).max >> 1);
+        _;
+    }
+
+    function testFuzz_Msb_Shifts2ToMoreThanX(uint256 x) external pure whenShiftLeftDoesNotOverflow(x) {
+        assertGt(2 << msb(x), x, "Common msb");
+    }
+}

--- a/test/fuzz/common/msb.t.sol
+++ b/test/fuzz/common/msb.t.sol
@@ -5,10 +5,10 @@ import { msb } from "src/Common.sol";
 
 import { Base_Test } from "../../Base.t.sol";
 
-/// @dev Collection of tests for the most significant bit function available in `Common.sol`.
-contract Common_Sqrt_Test is Base_Test {
+/// @dev Collection of tests for the most significant bit function `msb` available in `Common.sol`.
+contract Common_Msb_Test is Base_Test {
     function testFuzz_Msb_FitsUint8(uint256 x) external pure {
-        assertLe(msb(x), type(uint8).max, "Common msb");
+        assertLe(msb(x), type(uint8).max, "msb not within uint8 range");
     }
 
     modifier whenNotZero(uint256 x) {
@@ -17,19 +17,20 @@ contract Common_Sqrt_Test is Base_Test {
     }
 
     function testFuzz_Msb_ShiftsXToOneBit(uint256 x) external pure whenNotZero(x) {
-        assertEq(x >> msb(x), 1, "Common msb");
+        uint256 result = x >> msb(x);
+        assertEq(result, 1, "x / 2^{msb(x)} != 1");
     }
 
     function testFuzz_Msb_Shifts1ToLessThanOrEqualToX(uint256 x) external pure whenNotZero(x) {
-        assertLe(1 << msb(x), x, "Common msb");
+        assertLe(1 << msb(x), x, "2 ^ {msb(x)} not less than or equal to x");
     }
 
     modifier whenShiftLeftDoesNotOverflow(uint256 x) {
-        vm.assume(x <= type(uint256).max >> 1);
+        vm.assume(x <= type(uint256).max / 2);
         _;
     }
 
     function testFuzz_Msb_Shifts2ToMoreThanX(uint256 x) external pure whenShiftLeftDoesNotOverflow(x) {
-        assertGt(2 << msb(x), x, "Common msb");
+        assertGt(2 << msb(x), x, "2 ^ {msb(x)+1} not more than x");
     }
 }

--- a/test/fuzz/common/sqrt.t.sol
+++ b/test/fuzz/common/sqrt.t.sol
@@ -1,50 +1,40 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sqrt } from "src/Common.sol";
+import { sqrt, MAX_UINT128 } from "src/Common.sol";
 
 import { Base_Test } from "../../Base.t.sol";
 
-/// @dev Collection of tests for the square root function available in `Common.sol`.
+/// @dev Collection of tests for the square root function `sqrt` available in `Common.sol`.
 contract Common_Sqrt_Test is Base_Test {
-    uint256 internal constant MAX_SQRT = type(uint128).max;
+    uint256 internal constant MAX_SQRT = MAX_UINT128;
 
-    function testFuzz_Sqrt_Of256BitNumber(uint256 x) external pure {
-        vm.assertLe(sqrt(x) ** 2, x, "Common sqrt");
-        if (x < MAX_SQRT ** 2) {
-            vm.assertGt((sqrt(x) + 1) ** 2, x, "Common sqrt");
-        } else {
-            // This case cannot be tested nicely using 'vm.assume()',
-            // because the fuzzer fails to find enough valid input.
-            // That's why we have to embed it here with an 'if'.
-            vm.assertEq(sqrt(x), MAX_SQRT, "Common sqrt");
-        }
-    }
-
-    modifier whenSquareDoesNotOverflow(uint256 x) {
-        vm.assume(x <= MAX_SQRT);
-        _;
-    }
-
-    function testFuzz_Sqrt_OfPerfectSquare(uint256 x) external pure whenSquareDoesNotOverflow(x) {
-        vm.assertEq(sqrt(x ** 2), x, "Common sqrt");
-    }
-
-    modifier whenNotZero(uint256 x) {
-        vm.assume(x != 0);
-        _;
-    }
-
-    function testFuzz_Sqrt_OfAlmostPerfectSquare(uint256 x) external pure whenNotZero(x) whenSquareDoesNotOverflow(x) {
-        vm.assertEq(sqrt(x ** 2 - 1), x - 1, "Common sqrt");
-    }
-
-    modifier whenEven(uint256 x) {
+    function testFuzz_Sqrt_OfPowerOfTwo(uint8 x) external pure {
         vm.assume(x % 2 == 0);
-        _;
+        vm.assertEq(sqrt(2 ** x), 2 ** (x / 2), "incorrect sqrt of power of two");
     }
 
-    function testFuzz_Sqrt_OfPowerOfTwo(uint8 x) external pure whenEven(x) {
-        vm.assertEq(sqrt(2 ** x), 2 ** (x / 2), "Common sqrt");
+    function testFuzz_Sqrt_OfPerfectSquare(uint256 x) external pure {
+        x = bound(x, 0, MAX_SQRT);
+        vm.assertEq(sqrt(x ** 2), x, "incorrect sqrt of perfect square");
+    }
+
+    function testFuzz_Sqrt_OfAlmostPerfectSquare(uint256 x) external pure {
+        x = bound(x, 1, MAX_SQRT);
+        vm.assertEq(sqrt(x ** 2 - 1), x - 1, "incorrect sqrt of almost perfect square");
+    }
+
+    /// @dev Due to rounding down, `sqrt(x)` will be `MAX_SQRT` for all `x > MAX_SQRT ** 2`.
+    /// Recall that `MAX_SQRT` is 2^128 - 1.
+    function testFuzz_Sqrt_OfVeryLargeNumber(uint256 x) external pure {
+        x = bound(x, MAX_SQRT ** 2, type(uint256).max);
+        vm.assertEq(sqrt(x), MAX_SQRT, "incorrect sqrt of very large number");
+    }
+
+    /// @dev sqrt(x)^2 ≤ x < (sqrt(x) + 1)^2
+    function testFuzz_Sqrt(uint256 x) external pure {
+        x = bound(x, 0, MAX_SQRT ** 2 - 1);
+        vm.assertLe(sqrt(x) ** 2, x, "incorrect sqrt of very large number");
+        vm.assertLt(x, (sqrt(x) + 1) ** 2, "incorrect sqrt of very large number");
     }
 }

--- a/test/fuzz/common/sqrt.t.sol
+++ b/test/fuzz/common/sqrt.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sqrt } from "src/Common.sol";
+
+import { Base_Test } from "../../Base.t.sol";
+
+/// @dev Collection of tests for the square root function available in `Common.sol`.
+contract Common_Sqrt_Test is Base_Test {
+    uint256 internal constant MAX_SQRT = type(uint128).max;
+
+    function testFuzz_Sqrt_Of256BitNumber(uint256 x) external pure {
+        vm.assertLe(sqrt(x) ** 2, x, "Common sqrt");
+        if (x < MAX_SQRT ** 2) {
+            vm.assertGt((sqrt(x) + 1) ** 2, x, "Common sqrt");
+        } else {
+            // This case cannot be tested nicely using 'vm.assume()',
+            // because the fuzzer fails to find enough valid input.
+            // That's why we have to embed it here with an 'if'.
+            vm.assertEq(sqrt(x), MAX_SQRT, "Common sqrt");
+        }
+    }
+
+    modifier whenSquareDoesNotOverflow(uint256 x) {
+        vm.assume(x <= MAX_SQRT);
+        _;
+    }
+
+    function testFuzz_Sqrt_OfPerfectSquare(uint256 x) external pure whenSquareDoesNotOverflow(x) {
+        vm.assertEq(sqrt(x ** 2), x, "Common sqrt");
+    }
+
+    modifier whenNotZero(uint256 x) {
+        vm.assume(x != 0);
+        _;
+    }
+
+    function testFuzz_Sqrt_OfAlmostPerfectSquare(uint256 x) external pure whenNotZero(x) whenSquareDoesNotOverflow(x) {
+        vm.assertEq(sqrt(x ** 2 - 1), x - 1, "Common sqrt");
+    }
+
+    modifier whenEven(uint256 x) {
+        vm.assume(x % 2 == 0);
+        _;
+    }
+
+    function testFuzz_Sqrt_OfPowerOfTwo(uint8 x) external pure whenEven(x) {
+        vm.assertEq(sqrt(2 ** x), 2 ** (x / 2), "Common sqrt");
+    }
+}


### PR DESCRIPTION
Tests for mathematical properties of some functions in `Common.sol`. The implementation relies on the properties below.

For `msb()`:

$$ x = 0 \implies \text{msb}(x) = 0 $$
$$ x > 0 \implies x \gg \text{msb}(x) = 1 $$

For `sqrt()`:

$$ \left\lfloor\sqrt{x}\right\rfloor \leq \sqrt{x} < \left\lfloor\sqrt{x}\right\rfloor + 1 $$
$$ \left\lfloor\sqrt{x}\right\rfloor^2 \leq x < \left(\left\lfloor\sqrt{x}\right\rfloor + 1\right)^2 $$