### PR TITLE
Fix documentation typos and version inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ PRBMath provides adjacent value types that serve as abstractions over other vani
 
 These are useful if you want to save gas by using a lower bit width integer, e.g., in a struct.
 
-Note that these types don't have any mathematical functionality. To do math with them, you will have to unwrap them into a simple integer and then to
+Note that these types don't have any mathematical functionality. To do math with them, you will have to unwrap them into a simple integer and then cast to
 the core types `SD59x18` and `UD60x18`.
 
 ### 🔄 Casting Functions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,11 +10,11 @@ All issues have been timely addressed and are fixed in the latest version of PRB
 | Auditor | Type | Initial Commit                                                       | Report                                                                                                                            |
 | :------ | :--- | :------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
 | Certora | Firm | [prb-math@v4.0.0](https://github.com/PaulRBerg/prb-math/tree/v4.0.0) | [2023-07-12](https://medium.com/certora/problems-in-solidity-fixed-point-libraries-certora-bug-disclosure-987f504daca4)           |
-| Cantina | Firm | [prb-math@v3.3.3](https://github.com/PaulRBerg/prb-math/tree/v3.3.2) | [2023-06-08](https://github.com/sablier-labs/audits/blob/6567df3fa42b90663e3e694b1e776c6db337a3f2/v2-core/cantina-2023-06-08.pdf) |
+| Cantina | Firm | [prb-math@v3.3.2](https://github.com/PaulRBerg/prb-math/tree/v3.3.2) | [2023-06-08](https://github.com/sablier-labs/audits/blob/6567df3fa42b90663e3e694b1e776c6db337a3f2/v2-core/cantina-2023-06-08.pdf) |
 
 ## Cantina Review
 
-Cantina performed an audit of [Sablier Lockup](https://github.com/sablier-labs/v2-core) in June 2023, which included `prb-math@v3.3.3` in scope. Their
+Cantina performed an audit of [Sablier Lockup](https://github.com/sablier-labs/v2-core) in June 2023, which included `prb-math@v3.3.2` in scope. Their
 report included a finding in PRBMath:
 
 > 3.2.3 PRBMath pow() function can return inconsistent values


### PR DESCRIPTION

Changed "and then to" → "and then cast to" for clarity
Updated `v3.3.3` → `v3.3.2` to match actual release version 

