### PR TITLE
fix: check y == 0 before abs(x) in SD59x18 powu to handle MIN_SD59x18

### DIFF
--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -638,7 +638,7 @@ function pow(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
 /// - Returns `UNIT` for 0^0.
 ///
 /// Requirements:
-/// - Refer to the requirements in {abs} and {Common.mulDiv18}.
+/// - If y is greater than zero, refer to the requirements in {abs} and {Common.mulDiv18}.
 /// - The result must fit in SD59x18.
 ///
 /// @param x The base as an SD59x18 number.

--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -646,7 +646,7 @@ function pow(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
 /// @return result The result as an SD59x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function powu(SD59x18 x, uint256 y) pure returns (SD59x18 result) {
-  if (y == 0) return UNIT;
+    if (y == 0) return UNIT;
     uint256 xAbs = uint256(abs(x).unwrap());
 
     // Calculate the first iteration of the loop in advance.

--- a/src/sd59x18/Math.sol
+++ b/src/sd59x18/Math.sol
@@ -646,6 +646,7 @@ function pow(SD59x18 x, SD59x18 y) pure returns (SD59x18 result) {
 /// @return result The result as an SD59x18 number.
 /// @custom:smtchecker abstract-function-nondet
 function powu(SD59x18 x, uint256 y) pure returns (SD59x18 result) {
+  if (y == 0) return UNIT;
     uint256 xAbs = uint256(abs(x).unwrap());
 
     // Calculate the first iteration of the loop in advance.

--- a/test/unit/sd59x18/math/powu/powu.t.sol
+++ b/test/unit/sd59x18/math/powu/powu.t.sol
@@ -47,6 +47,7 @@ contract Powu_Unit_Test is SD59x18_Unit_Test {
 
     function exponentZero_Sets() internal returns (Set[] memory) {
         delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: 1e18 }));
         sets.push(set({ x: MIN_SD59x18 + sd(1), expected: 1e18 }));
         sets.push(set({ x: NEGATIVE_PI, expected: 1e18 }));
         sets.push(set({ x: -1e18, expected: 1e18 }));


### PR DESCRIPTION
## Summary

`powu(MIN_SD59x18, 0)` currently reverts instead of returning `UNIT`.

`abs()` is called before the `y == 0` short-circuit check, and `abs(MIN_SD59x18)` 
always reverts. Mathematically, `x^0 = 1` for all x including `MIN_SD59x18`.

Compare with `pow()` which correctly handles `y == 0` before touching `x`.

## Fix

Move the `y == 0` guard before the `abs(x)` call:

```solidity
function powu(SD59x18 x, uint256 y) pure returns (SD59x18 result) {
    if (y == 0) return UNIT;
    uint256 xAbs = uint256(abs(x).unwrap());
```